### PR TITLE
Add worker strategy documentation

### DIFF
--- a/docs/workers/exhaustive-worker.md
+++ b/docs/workers/exhaustive-worker.md
@@ -1,0 +1,107 @@
+# Exhaustive Worker
+
+## Overview
+
+The exhaustive worker is the primary workhorse of the Ramsey system. It systematically evaluates every possible 2-edge flip (one red edge + one blue edge) on the current base graph, looking for flips that reduce the total clique count. This is a brute-force approach that guarantees no 2-edge improvement is missed within a given stage.
+
+The exhaustive search is what drives stage progression: once all pairs have been evaluated, the queue manager advances to the next stage using the best result found.
+
+## High-Level Strategy
+
+Given a graph with R red edges and B blue edges, there are R x B possible (red, blue) edge pairs. Each pair represents a candidate mutation: flip the red edge to blue and the blue edge to red simultaneously. The worker evaluates each pair by computing how the flip changes the total clique count using the Bron-Kerbosch algorithm.
+
+The search space is divided across multiple workers using Redis atomic counters. Each worker claims a batch of index ranges, converts indices to edge pairs via the enumeration strategy, and processes them independently. This allows horizontal scaling with no coordination overhead beyond the atomic counter.
+
+### Work Distribution
+
+1. The queue manager seeds a Redis key `stage_work_index:{stageId}` with the starting index (0).
+2. Each worker atomically increments this counter by its `WORK_UNIT_FETCH_COUNT` (batch size) via `INCRBY`.
+3. The returned value defines the exclusive range `[prev, prev + batch_size)` of work unit indices.
+4. The worker converts each index to an edge pair using the configured enumeration strategy.
+5. When the counter exceeds `total_pairs`, the stage is fully claimed.
+
+### Enumeration Strategies
+
+Edge pairs can be enumerated in different orders, controlled by `WORK_ENUMERATION_STRATEGY`:
+
+- **BASIC** -- Simple row-major iteration. Red edges and blue edges are listed in vertex-pair order. Index `i` maps to `red[i / blue_count]` + `blue[i % blue_count]`. No prioritization.
+- **DUAL_EDGE_CARDINALITY** (current default) -- Both red and blue edge lists are sorted by cardinality descending before enumeration. Cardinality is the count of same-colored edges adjacent to the edge's endpoints. High-cardinality edges participate in more cliques, so evaluating them first means improvements are found earlier in the stage, which benefits the top-N tracking.
+
+### Clique Evaluation
+
+For each edge pair, the worker computes the resulting clique count using an incremental approach:
+
+1. Look up how many existing cliques contain the edges being flipped (the "broken" count) from the pre-built `CliqueCollection`.
+2. Temporarily flip the edges on the working graph.
+3. Run seeded Bron-Kerbosch to count new cliques formed by the flip.
+4. Compute: `new_total = base_total - broken + new_cliques`.
+5. Unflip the edges to restore the graph.
+
+The `CliqueCollection` is built once per stage by enumerating all cliques of the target size (8-cliques for 288 vertices) using a comprehensive Bron-Kerbosch pass. It provides O(1) lookup of which cliques contain a given edge, enabling the incremental formula above.
+
+### Early Termination
+
+When `PUBLISH_RESULTS=false` (the default for local deployments), the worker uses early termination during Bron-Kerbosch. If the new clique count exceeds the current top-N threshold, enumeration stops immediately. This dramatically reduces computation for clearly-bad mutations -- the worker only does full counting for mutations that have a chance of being competitive.
+
+### Top-N Result Tracking
+
+Results are tracked in a Redis sorted set `best_results:{stageId}` of size `TOP_RESULTS_COUNT` (default 50). Only results that beat the worst entry in this set are submitted. The queue manager reads this set when deciding the best result for stage advancement.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKER_MODE` | `EXHAUSTIVE` | Omit or set to `EXHAUSTIVE` for this mode |
+| `WORK_UNIT_FETCH_COUNT` | `50000` | Batch size per Redis claim |
+| `WORK_UNIT_PUBLISH_COUNT` | `50000` | Batch size for MySQL result submission |
+| `WORK_UNIT_POLL_FREQ` | `1000` | Poll interval (ms) when no work available |
+| `PUBLISH_RESULTS` | `true` | Whether to write results to MySQL (set `false` for top-N only mode) |
+| `TOP_RESULTS_COUNT` | `10` | Size of the top-N sorted set in Redis |
+| `WORKER_COUNT` | `$(nproc)` | Number of worker processes per container (Dockerfile-level, defaults to CPU count) |
+
+## Typical Production Configuration (Docker Compose)
+
+```yaml
+ramsey-worker-rust:
+  image: benferenchak/ramsey-worker-rust:develop
+  environment:
+    RAMSEY_API_URL: http://ramsey-mw:8080/api/ramsey
+    RAMSEY_CAMPAIGN_ID: 1
+    REDIS_HOST: redis
+    REDIS_PORT: 6379
+    WORK_UNIT_FETCH_COUNT: 250000
+    PUBLISH_RESULTS: "false"
+    TOP_RESULTS_COUNT: 50
+    WORKER_COUNT: 1
+  scale: 14
+```
+
+## Sample Log Output
+
+```
+[2026-04-13T12:37:17.343Z] Processed 250000 work items in 285444ms
+[2026-04-13T12:38:13.528Z] Processed 250000 work items in 56184ms
+[2026-04-13T12:48:22.651Z] Added to top-50 results for stage 4994: clique_count=980120
+[2026-04-13T12:48:25.932Z] Added to top-50 results for stage 4994: clique_count=980102
+```
+
+The first batch of a new stage takes longer (~285s) because it includes building the graph and clique collection. Subsequent batches process in ~55-65s. "Added to top-50" lines appear when a mutation beats the current worst in the top-N set.
+
+## Performance Characteristics
+
+- At 288 vertices with the DUAL_EDGE_CARDINALITY strategy, the total search space per stage is ~427 million edge pairs.
+- With 14 workers each claiming 250K batches, a full stage exhaustion takes ~90 minutes.
+- The first batch per stage is ~4-5x slower due to clique collection construction.
+- Graph and clique collection are cached across stages when the base graph is reused.
+
+## Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `ramsey-worker-rust/src/worker.rs` | `cycle_counter_based()` -- main work loop |
+| `ramsey-worker-rust/src/enumeration.rs` | Work index to edge pair conversion, enumeration strategies |
+| `ramsey-worker-rust/src/algorithm.rs` | `get_new_cliques_with_limit()` -- Bron-Kerbosch with early termination |
+| `ramsey-worker-rust/src/clique_collection.rs` | Per-edge clique participation index |
+| `ramsey-worker-rust/src/redis_client.rs` | `claim_work_range()`, `add_to_top_results()` |
+| `ramsey-worker-rust/src/graph.rs` | `Graph` struct, `flip_edges()`, bitstring serialization |
+| `ramsey-worker-rust/src/bitset.rs` | `BitMatrix` for fast adjacency lookups |

--- a/docs/workers/simulated-annealing-worker.md
+++ b/docs/workers/simulated-annealing-worker.md
@@ -1,0 +1,113 @@
+# Simulated Annealing (SA) Worker
+
+## Overview
+
+The SA worker uses a metaheuristic approach to escape local minima that the exhaustive search cannot reach. Unlike the exhaustive worker which evaluates all 2-edge flips deterministically, SA performs random multi-edge mutations and probabilistically accepts worsening moves early in the schedule, allowing it to traverse through higher-energy states to potentially find better basins.
+
+SA was investigated extensively (see `docs/simulated-annealing-investigation.md`). After 45,000+ iterations across multiple parameter configurations, it found zero improvements over the exhaustive search baseline, suggesting the landscape at ~980K cliques is too rugged for SA to navigate effectively. SA workers are currently scaled to 0 in production but the infrastructure remains available.
+
+## High-Level Strategy
+
+Each SA run executes a complete annealing schedule starting from the current stage's base graph:
+
+1. Initialize temperature to `initial_temp`.
+2. For each iteration (up to `max_iterations`):
+   a. Cool temperature: `temp *= cooling_rate`.
+   b. Pick a random number of edge pairs in `[min_pairs, max_pairs]`.
+   c. Select that many red edges and blue edges via weighted sampling.
+   d. Flip all selected edges simultaneously.
+   e. Recount cliques comprehensively (full Bron-Kerbosch).
+   f. Accept or reject via the Metropolis criterion.
+3. Report the best graph found across all iterations.
+
+### Edge Selection: Clique-Guided Weighted Sampling
+
+Edge selection is not uniform random. The worker builds participation-weighted edge lists from the base graph's `CliqueCollection`:
+
+- Weight = `1 / (clique_participation + 1)`
+- Edges involved in fewer cliques get higher weight.
+- This biases selection toward edges whose flipping is less disruptive, increasing the chance of finding moves that actually reduce clique count.
+
+Red and blue edges are sampled separately, with equal counts from each (maintaining the total edge count). Sampling is without replacement within each iteration.
+
+### Acceptance Criterion (Metropolis)
+
+- If `delta <= 0` (clique count decreased or stayed same): always accept.
+- If `delta > 0` (clique count increased): accept with probability `exp(-delta / temp)`.
+- At high temperatures, large worsening moves are accepted frequently, enabling exploration.
+- As temperature decreases, only small worsening moves are accepted, converging toward local optima.
+
+### State Management
+
+When a move is accepted, the flipped edges are moved between the red and blue edge lists (red edges become blue, blue become red). Their weights are preserved from the initial computation -- they are not recomputed during the run. This is a deliberate approximation: recomputing the full clique collection after each flip would be prohibitively expensive, and the initial weights provide a stable heuristic throughout the schedule.
+
+### Result Submission
+
+After the schedule completes, if the best graph found improves on the initial state and beats the current top-N threshold, it is submitted as a full graph bitstring (not as edge flips, since SA may apply hundreds of mutations). The worker uses `add_sa_result_to_top_results()` which stores the complete graph state.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKER_MODE` | -- | Set to `SIMULATED_ANNEALING` |
+| `SA_MAX_ITERATIONS` | `100000` | Total iterations per annealing schedule |
+| `SA_INITIAL_TEMP` | `1000.0` | Starting temperature |
+| `SA_COOLING_RATE` | `0.999` | Geometric cooling factor per iteration |
+| `SA_MIN_PAIRS` | `2` | Minimum red+blue edge pairs per mutation |
+| `SA_MAX_PAIRS` | `5` | Maximum red+blue edge pairs per mutation |
+| `TOP_RESULTS_COUNT` | `10` | Size of the top-N sorted set in Redis |
+
+## Typical Configuration (Docker Compose)
+
+```yaml
+ramsey-worker-rust-sa:
+  image: benferenchak/ramsey-worker-rust:develop
+  environment:
+    WORKER_MODE: SIMULATED_ANNEALING
+    SA_MAX_ITERATIONS: 15000
+    SA_INITIAL_TEMP: 1000.0
+    SA_COOLING_RATE: 0.999
+    SA_MIN_PAIRS: 2
+    SA_MAX_PAIRS: 2
+    TOP_RESULTS_COUNT: 50
+    WORKER_COUNT: 1
+  scale: 0  # Currently disabled
+```
+
+## Sample Log Output
+
+```
+SA starting: vertex_count=288, clique_size=8, initial_cliques=980088, threshold=none,
+  max_iterations=15000, initial_temp=1000.00, cooling_rate=0.9990, min_pairs=2, max_pairs=2
+SA iter 1/15000: temp=999.00, pairs=2, new_cliques=980412, accepted=true, current=980412, best=980088
+SA iter 2/15000: temp=998.00, pairs=2, new_cliques=980285, accepted=true, current=980285, best=980088
+...
+SA iter 15000/15000: temp=0.00, pairs=2, new_cliques=980301, accepted=false, current=980150, best=980088
+SA finished: initial_cliques=980088, best_cliques=980088, improved=false
+```
+
+Note: SA logs every iteration, which produces high log volume. Each run takes several minutes for the full schedule.
+
+## Performance Characteristics
+
+- Each iteration requires a full `get_cliques_comprehensive()` call (complete Bron-Kerbosch enumeration), which is the dominant cost.
+- At 288 vertices / 8-cliques, each iteration takes ~1-5ms, so a 15,000-iteration schedule runs in ~30-60 seconds.
+- SA explores a fundamentally different dimension than exhaustive search: multi-edge mutations with probabilistic acceptance vs. guaranteed-optimal single-pair evaluation.
+- The `min_pairs=2` setting ensures SA explores at least 4-edge flips (2 red + 2 blue), since the exhaustive search already covers all 2-edge (1 red + 1 blue) combinations.
+
+## Current Status
+
+SA is **disabled in production** (scale: 0). The investigation (`docs/simulated-annealing-investigation.md`) documented that after extensive parameter tuning, SA could not find improvements at the current optimization depth (~980K cliques). The landscape appears too rugged -- the temperature schedule either cools too fast to escape local minima or stays too hot to converge.
+
+SA remains a viable approach if the problem parameters change significantly (e.g., different vertex count, different clique size, or if the landscape becomes smoother at a different optimization depth).
+
+## Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `ramsey-worker-rust/src/sa.rs` | `run_sa()` -- complete SA implementation |
+| `ramsey-worker-rust/src/sa.rs` | `build_edge_list()` -- weighted edge list construction |
+| `ramsey-worker-rust/src/sa.rs` | `weighted_sample()` -- weighted sampling without replacement |
+| `ramsey-worker-rust/src/worker.rs` | `cycle_simulated_annealing()` -- worker loop integration |
+| `ramsey-worker-rust/src/algorithm.rs` | `get_cliques_comprehensive()` -- full clique recount used each iteration |
+| `docs/simulated-annealing-investigation.md` | Detailed investigation results and parameter tuning history |

--- a/docs/workers/variable-depth-search-worker.md
+++ b/docs/workers/variable-depth-search-worker.md
@@ -1,0 +1,162 @@
+# Variable-Depth Search (VDS) Worker
+
+## Overview
+
+The VDS worker performs structured, guided tree search through sequences of edge flips, inspired by the Lin-Kernighan heuristic for TSP. Unlike the exhaustive worker (which evaluates all 2-edge flips) or SA (which makes random jumps), VDS chains together multi-flip sequences where each subsequent flip targets the local neighborhood disrupted by prior flips.
+
+VDS is designed to complement the exhaustive search by exploring the 3+ edge flip space that exhaustive workers cannot reach. With `start_depth=3`, VDS begins every run from a random 3-flip starting point, ensuring it only explores territory that no other worker type covers.
+
+## High-Level Strategy
+
+Each VDS run follows this structure:
+
+1. **Rank edges** by clique participation score (how many cliques each edge belongs to). Take the top `top_first_edges` as the candidate pool.
+2. **Sample** `branching_factor` random first edges from this pool.
+3. For each sampled first edge:
+   a. **Build a random prefix** of `start_depth - 1` additional flips by picking one random neighborhood edge at each level.
+   b. **Begin branching search** from the prefix endpoint, exploring up to `max_depth` total flips.
+   c. At each depth, select `branching_factor` candidates from the local neighborhood (edges incident to vertices already touched by the flip sequence).
+   d. **Prune** branches where the cumulative clique count worsens by more than `worsening_tolerance` relative to the prefix endpoint.
+   e. **Track** the best sequence that improves on `base_clique_count`.
+4. **Verify** any improvement via comprehensive Bron-Kerbosch recount before submission.
+
+### The Prefix: Why start_depth Matters
+
+The exhaustive workers already evaluate every possible 2-edge flip. Without `start_depth`, VDS would redundantly search the same 1- and 2-flip space. By setting `start_depth=3`:
+
+- Depth 1: one random first edge from the top-200 pool (no branching)
+- Depth 2: one random neighborhood edge (no branching)
+- Depth 3-8: branching search begins, with `branching_factor` candidates per level
+
+Each run starts from a different random 3-flip state, then searches for additional flips that bring the total clique count below the original base. The prefix path is different every run, ensuring broad coverage of the 3+ flip space.
+
+### Randomized Candidate Selection
+
+Diversity between runs is achieved through two mechanisms:
+
+1. **First-edge sampling**: The top `top_first_edges` (200) edges are ranked by global clique participation, shuffled, and `branching_factor` (15) are sampled per run. Different first edges are tried each run.
+
+2. **Neighborhood candidate shuffling**: At each search depth, `get_neighborhood_candidates()` collects all edges incident to vertices touched by the current flip sequence, ranks them by surviving clique participation, takes a 3x quality-filtered pool, shuffles it, and returns `branching_factor` candidates. This ensures each run explores different subtrees while keeping candidates focused on high-participation edges.
+
+### Worsening Tolerance and the Tolerance Base
+
+The `worsening_tolerance` parameter controls how far the search can deviate above the tolerance baseline before a branch is pruned. Crucially, the tolerance is measured from the **cumulative clique count at the end of the prefix** (not the original base graph count). This is important because:
+
+- The random 2-flip prefix may put the count significantly above the original base.
+- If tolerance were measured from the original base, most branches would be immediately pruned.
+- By measuring from the prefix endpoint, the search can explore the local landscape around each random 3-flip state.
+
+Improvements are still tracked against the **original** `base_clique_count` -- a result is only reported if the full flip sequence (prefix + search) produces fewer cliques than the unmodified base graph.
+
+### Incremental Clique Counting
+
+VDS uses the same incremental delta computation as the exhaustive worker:
+
+```
+delta = -broken_cliques + new_cliques
+```
+
+Where `broken_cliques` are read from the `CliqueCollection` (adjusted for previously destroyed cliques in the sequence) and `new_cliques` are computed via seeded Bron-Kerbosch on the flipped graph. The graph is flipped and unflipped for each evaluation without modification to the CliqueCollection, enabling backtracking.
+
+A `destroyed` set tracks which cliques from the original CliqueCollection have been invalidated by prior flips in the sequence, ensuring the broken count is not double-counted.
+
+### Verification
+
+When an improvement is found, VDS performs a comprehensive recount (`get_cliques_comprehensive()`) on the fully-flipped graph to verify the incremental delta tracking was accurate. If there is a mismatch (which would indicate a bug in the destroyed-set tracking), the result is discarded and logged as a verification failure.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKER_MODE` | -- | Set to `VARIABLE_DEPTH_SEARCH` |
+| `VDS_MAX_DEPTH` | `4` | Maximum total flips in a sequence (including prefix) |
+| `VDS_TOP_FIRST_EDGES` | `500` | Size of the first-edge candidate pool (ranked by participation) |
+| `VDS_BRANCHING_FACTOR` | `20` | Candidates explored per depth level + first edges sampled per run |
+| `VDS_WORSENING_TOLERANCE` | `100` | Max allowed worsening from the tolerance base before pruning |
+| `VDS_START_DEPTH` | `1` | Depth at which branching begins (prefix edges are random, unbranched) |
+| `VDS_RANDOM_SEED` | None | Fixed seed for reproducibility (omit for OS entropy) |
+| `TOP_RESULTS_COUNT` | `10` | Size of the top-N sorted set in Redis |
+
+## Typical Production Configuration (Docker Compose)
+
+```yaml
+ramsey-worker-rust-vds:
+  image: benferenchak/ramsey-worker-rust:develop
+  environment:
+    WORKER_MODE: VARIABLE_DEPTH_SEARCH
+    VDS_MAX_DEPTH: 8
+    VDS_TOP_FIRST_EDGES: 200
+    VDS_BRANCHING_FACTOR: 15
+    VDS_WORSENING_TOLERANCE: 1000
+    VDS_START_DEPTH: 3
+    TOP_RESULTS_COUNT: 50
+    WORKER_COUNT: 1
+  scale: 1
+```
+
+## Sample Log Output
+
+```
+[2026-04-13T12:49:06.025Z] VDS starting: vertex_count=288, clique_size=8, base_cliques=980090,
+  max_depth=8, top_first_edges=200, branching_factor=15, worsening_tolerance=1000, start_depth=3
+[2026-04-13T12:49:13.344Z] VDS finished: no improvement found, elapsed_ms=7317,
+  nodes_visited=8610, branches_pruned=8018
+[2026-04-13T12:49:13.385Z] Processed 1 work items in 8426ms
+```
+
+When an improvement is found (not yet observed at 980K cliques):
+```
+VDS verified: base=980090, final=980085, delta=-5, sequence_len=4,
+  elapsed_ms=12345, nodes_visited=9500, branches_pruned=8800
+```
+
+## Performance Characteristics (Production Observations)
+
+After ~7,000 runs with current production settings:
+
+| Metric | Value |
+|--------|-------|
+| Avg search time per run | ~8.2s |
+| Avg nodes visited per run | ~7,340 |
+| Avg branches surviving pruning | ~500 (out of ~7,340 visited) |
+| Prune rate | ~93% |
+| Distinct `nodes_visited` values | 476+ across 7,000 runs |
+| Runs per minute | ~7 |
+| Stage transitions observed | 13 (stages 4982-4994) |
+| Improvements found | 0 (expected at 980K cliques) |
+
+The high diversity in `nodes_visited` values (476 distinct values across 7,000 runs) confirms that each run explores genuinely different territory. The consistent ~93% prune rate indicates the tolerance is well-calibrated: selective enough to focus computation but permissive enough for meaningful depth exploration.
+
+## Relationship to Other Worker Types
+
+| Dimension | Exhaustive | SA | VDS |
+|-----------|-----------|-----|-----|
+| Search space | All 2-edge flips | Random multi-edge jumps | Guided multi-edge sequences |
+| Coverage | Complete (for 2-flip) | Stochastic | Stochastic |
+| Depth | 2 edges | N edges (random) | 3-8 edges (structured) |
+| Selection | Deterministic enumeration | Weighted random | Participation-ranked + random |
+| Acceptance | Best result wins | Metropolis criterion | Any improvement over base |
+| Unique value | Guarantees no 2-flip improvement is missed | Can escape local minima via temperature | Finds structured multi-flip improvements in local neighborhoods |
+
+VDS occupies the middle ground: more structured than SA (each flip builds on the previous one's neighborhood) but capable of exploring deeper than exhaustive search. The `start_depth=3` setting ensures zero overlap with exhaustive workers.
+
+## Tuning Guidance
+
+- **`worsening_tolerance`**: Higher values allow deeper exploration but increase per-run time. At 980K cliques, 1000 gives ~93% prune rate and ~8s runs. Values above 2000 may cause runs to exceed 20s.
+- **`top_first_edges`**: Larger pools give more diverse starting points. 200 is a good balance; above 500 includes low-participation edges that are unlikely to lead to improvements.
+- **`branching_factor`**: Controls both first-edge sampling and per-level branching. 15 gives ~7 runs/minute. Increasing to 20-25 would deepen search but reduce throughput.
+- **`max_depth`**: 8 is generous; most productive exploration happens at depths 3-5. The worsening tolerance naturally limits effective depth.
+- **`start_depth`**: Should be >= 3 when running alongside exhaustive workers to avoid redundant coverage. Setting to 4+ would narrow the search further but skip potentially valuable 3-flip combinations.
+
+## Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `ramsey-worker-rust/src/vds.rs` | `run_vds()` -- main entry point, prefix building, first-edge sampling |
+| `ramsey-worker-rust/src/vds.rs` | `build_prefix_and_search()` -- random prefix construction before branching |
+| `ramsey-worker-rust/src/vds.rs` | `search_depth()` -- recursive branching search with tolerance pruning |
+| `ramsey-worker-rust/src/vds.rs` | `get_neighborhood_candidates()` -- locality-aware candidate selection with 3x pool shuffling |
+| `ramsey-worker-rust/src/vds.rs` | `rank_edges_by_participation()` -- global edge ranking for first-edge pool |
+| `ramsey-worker-rust/src/vds.rs` | `compute_delta()` -- incremental clique count change for a single flip |
+| `ramsey-worker-rust/src/worker.rs` | `cycle_variable_depth_search()` -- worker loop integration |
+| `docs/vds-enhancements.md` | Earlier VDS design notes and enhancement ideas |


### PR DESCRIPTION
## Summary
- Adds `docs/workers/` with three markdown files documenting the Exhaustive, Simulated Annealing, and Variable Depth Search worker strategies
- Covers architecture, configuration options, and usage guidance for each strategy

## Test plan
- [ ] Docs render correctly on GitHub
- [ ] No code changes included

🤖 Generated with [Claude Code](https://claude.com/claude-code)