### PR TITLE
chore: add Redis persistence and restart policy

### DIFF
--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -4,13 +4,16 @@ services:
 
   redis:
     image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
-    command: dragonfly --maxmemory 7gb
+    command: dragonfly --maxmemory 7gb --snapshot_cron "*/5 * * * *" --dbfilename dump --dir /data
     networks:
       - ramsey-net
     ports:
       - "36002:6379"
+    volumes:
+      - dragonfly-data:/data
     mem_limit: 8g
     scale: 1
+    restart: on-failure
     logging:
       driver: loki
       options:
@@ -660,3 +663,6 @@ services:
 networks:
   ramsey-net:
     external: true
+
+volumes:
+  dragonfly-data:


### PR DESCRIPTION
## Summary
- Add \`restart: on-failure\` to redis service (other services already had it; redis was missing it, so it didn't come back after Mac reboot)
- Enable Dragonfly RDB snapshotting every 5 min via \`--snapshot_cron\`, \`--dbfilename\`, \`--dir\`
- Add named volume \`dragonfly-data\` mounted at \`/data\` for snapshot persistence

Prevents losing in-flight stage progress (work counters, top-N sorted sets, best-results state) on host restart or container recreation.

Already deployed and verified on production stack.

## Test plan
- [x] Deployed to Portainer, verified redis container running healthy with new flags
- [x] Verified \`ramsey_dragonfly-data\` volume mounted at \`/data\`
- [x] Verified middleware still connecting to MySQL (active stage queryable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)