### PR TITLE
chore: VDS Phase 3 experiment

### DIFF
--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -115,7 +115,7 @@ services:
         loki-external-labels: "machine=MacBook-Pro-M4Max-1,service_name={{.Name}}"
     restart: on-failure
     mem_limit: 2g
-    scale: 14
+    scale: 6
 
   ramsey-worker-rust-sa:
     image: benferenchak/ramsey-worker-rust:develop
@@ -162,10 +162,10 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       WORKER_MODE: VARIABLE_DEPTH_SEARCH
-      VDS_MAX_DEPTH: 8
-      VDS_TOP_FIRST_EDGES: 200
-      VDS_BRANCHING_FACTOR: 15
-      VDS_WORSENING_TOLERANCE: 1000
+      VDS_MAX_DEPTH: 12
+      VDS_TOP_FIRST_EDGES: 80
+      VDS_BRANCHING_FACTOR: 12
+      VDS_WORSENING_TOLERANCE: 500
       VDS_START_DEPTH: 3
       TOP_RESULTS_COUNT: 50
       WORKER_COUNT: 1
@@ -185,7 +185,7 @@ services:
         loki-external-labels: "machine=MacBook-Pro-M4Max-1,service_name={{.Name}}"
     restart: on-failure
     mem_limit: 2g
-    scale: 0
+    scale: 8
 
   ramsey-ui:
     image: benferenchak/ramsey-ui:develop


### PR DESCRIPTION
Apply VDS Phase 3 settings and scale 0 -> 8, reducing exhaustive 14 -> 6. Total compute unchanged.

Final fair evaluation of VDS with literature-recommended settings before retiring.