### PR TITLE
chore: add tabu worker service to compose

### DIFF
--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -187,6 +187,42 @@ services:
     mem_limit: 2g
     scale: 0
 
+  ramsey-worker-rust-tabu:
+    image: benferenchak/ramsey-worker-rust:develop
+    networks:
+      - ramsey-net
+    environment:
+      RAMSEY_API_URL: http://ramsey-mw:8080/api/ramsey
+      RAMSEY_CAMPAIGN_ID: 2
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      WORKER_MODE: TABU_CLIQUE_GUIDED
+      TABU_MAX_ITERATIONS: 50000
+      TABU_BASE_TENURE: 200
+      TABU_MAX_TENURE: 400
+      TABU_RESTART_AFTER: 5000
+      TABU_CANDIDATE_POOL_SIZE: 20
+      TABU_DIVERSIFICATION_PAIRS: 15
+      TOP_RESULTS_COUNT: 50
+      WORKER_COUNT: 1
+    depends_on:
+      ramsey-mw:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://loki.setminusx.cloud/loki/api/v1/push"
+        mode: non-blocking
+        max-buffer-size: 4m
+        loki-retries: 5
+        loki-batch-size: 1000
+        loki-external-labels: "machine=MacBook-Pro-M4Max-1,service_name={{.Name}}"
+    restart: on-failure
+    mem_limit: 2g
+    scale: 0
+
   ramsey-ui:
     image: benferenchak/ramsey-ui:develop
     networks:


### PR DESCRIPTION
Defines ramsey-worker-rust-tabu pool at scale 0, ready for opt-in A/B once the worker image with TABU_CLIQUE_GUIDED is published.