### PR TITLE
Accept DUAL_EDGE_CARDINALITY_WITH_SINGLES stage strategy

### DIFF
--- a/src/main/java/com/setminusx/ramsey/mw/entity/Stage.java
+++ b/src/main/java/com/setminusx/ramsey/mw/entity/Stage.java
@@ -47,7 +47,8 @@ public class Stage {
     public enum WorkEnumerationStrategy {
         BASIC,
         SINGLE_EDGE_CARDINALITY,
-        DUAL_EDGE_CARDINALITY
+        DUAL_EDGE_CARDINALITY,
+        DUAL_EDGE_CARDINALITY_WITH_SINGLES
     }
 
 }


### PR DESCRIPTION
One-line enum addition so stage creation/persistence accepts the new strategy from the queue manager. EnumType.STRING column — no migration. deriveGraph already parses 1-edge flip lists. Companion to ramsey-worker-rust#64.

Generated with [Claude Code](https://claude.com/claude-code)