### PR TITLE
Fix unpublished tabu-test image tag blocking stack redeploys

### DIFF
--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -188,7 +188,7 @@ services:
     scale: 0
 
   ramsey-worker-rust-tabu:
-    image: benferenchak/ramsey-worker-rust:tabu-test
+    image: benferenchak/ramsey-worker-rust:develop
     networks:
       - ramsey-net
     environment:


### PR DESCRIPTION
Portainer stack update with pullImage aborted: `benferenchak/ramsey-worker-rust:tabu-test` was never pushed to Docker Hub (documented in the tabu retirement notes). The dormant tabu service now uses `:develop`, which contains the tabu mode (selected via WORKER_MODE env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)