### PR TITLE
docs: investigation writeups (best-novel plan, joint/row-opt, search status)

### DIFF
--- a/docs/investigations/best-novel-threshold-plan.md
+++ b/docs/investigations/best-novel-threshold-plan.md
@@ -1,0 +1,337 @@
+# Best-Novel Threshold + Cross-Worker Learning — Implementation Plan
+
+**Status:** ✅ SHIPPED 2026-06-19 — Phases 1–2 implemented, deployed to the live 14-worker stack, and validated. Merged to `develop` (worker PR #69, QM PR #73). · **Originally planned:** 2026-06-16
+
+## Status / outcome (2026-06-19)
+
+**Shipped, worker-only** (lower risk than the original 3-phase split — the QM needed no code change):
+- **Phase 1 (hash parity):** `ramsey-worker-rust/src/hash.rs` (`derived_graph_hash`/`graph_hash`) byte-for-byte matches the QM `GraphHashUtil`; shared SHA-256 vectors asserted in **both** repos' tests (worker 5 tests, QM `GraphHashUtilTest`).
+- **Phase 2 (novel-only cache):** insert Lua (`add_to_top_results`) now does `SISMEMBER processed_graph_hashes` and rejects visited graphs; `get_top_results_threshold` reads **slot 0** (best novel, active after the first entry). Worker computes the derived hash only at the rare record-breaker insert sites.
+- **No QM code change:** the QM already walks `best_results` for the best *unprocessed* graph and already early-adopts a novel improvement in SCENARIO 1 — a novel-only set makes slot 0 always-novel, so it "just works." Only a parity test was added to the QM.
+
+**Deviations from the original plan (all deliberate):**
+- **Kept `TOP_RESULTS_COUNT=50`** (did not drop to 5). The u/s win comes from threshold=slot0, not K; with slot-0 semantics only record-breakers insert, so ZSETs naturally hold ~20–25 entries anyway. No compose change needed.
+- **No fold-into-claim Lua, no `THRESHOLD_REFRESH_UNITS`** — per-batch `get_top_results_threshold` (now slot 0) + own-insert tightening was sufficient; deferred as premature.
+- **No stage-start threshold seed** — plateau-escape risk; deferred per §15.
+
+**Deploy:** built the worker image locally (arm64 generic, matches production `:develop`), recreated the 14 workers via `docker compose --no-deps --force-recreate` (redis/mw/qm untouched), then merged to `develop` so CI rebuilds the canonical Hub `:develop` (durability — the running local image would otherwise revert on the next reboot/pull).
+
+**Validation (live):** insert-Lua exercised on live Dragonfly (novel insert / K-trim / visited-reject); production hashes consistent at n=282 (no worker↔QM mismatch); post-deploy stage ZSETs clean (0 visited / 23 entries); the "improvement but already processed → exhaustion" limbo **disappeared** on clean stages; **early-adopt fired** (bases descended 25959→25943→25927 with ~30s-apart progressions, impossible via 9-min exhaustion); 14 workers healthy, ~700k u/s. Still cycling the ~25,9xx plateau (this speeds/de-risks the grind, it does not escape the basin — as predicted in §15).
+
+**Lesson — transitional contamination:** recreating workers *mid-stage* leaves the in-flight stage's ZSET with whatever the old (non-filtering) workers had inserted (saw a stale visited slot-0 on the stage created during the recreate). Harmless — the QM's unprocessed-fallback handled it and it cleared on the next progression — but for a clean cutover, prefer recreating at a stage boundary.
+
+---
+
+
+This is "Option B" from the throughput discussion. It changes the per-stage
+`best_results` sorted set from "top-50 graphs by clique count" to "best *novel*
+(unvisited) graphs," and makes that set the shared learning channel through
+which all workers tighten their early-exit threshold. The net effects are:
+higher work-unit throughput (u/s), robustness against dead-ends, an early-adopt
+fast path that stops grinding stages to full exhaustion, and a simpler QM.
+
+---
+
+## 1. Motivation & live evidence
+
+### The u/s ramp
+With `PUBLISH_RESULTS=false`, a work unit is "retired" either **cheaply**
+(early-termination bails when its base count can't beat the current top-N
+threshold) or **expensively** (full clique count). Observed: u/s starts ~200k/s
+on a fresh stage and climbs toward ~1M/s by stage end. Cause: the early-exit
+threshold tightens as the `best_results` cache fills with better graphs.
+
+Two sources of slack in today's design:
+1. A fresh stage starts with an empty set → threshold `None` → **full-count
+   everything** until the set fills to 50 (slow opening).
+2. The threshold is the **50th-best** score (worst of the kept set), not the
+   best — so even once active it's looser than it could be.
+
+### The dead-end / cycle evidence (stage 8712, 2026-06-17 UTC)
+Captured live: stage 8712 fully processed (392,495,529 / 392,495,529), 50
+best_results clustered 25,840–25,999, all on base graph 8712 (count 25,920).
+The QM logged for ~5.5 min, every 30s:
+
+```
+Improvement found (cliques=25840) but graph already processed, treating as exhaustion case
+```
+
+SCENARIO 1 only checks the **single best** (25,840) — a real 80-clique
+improvement, but already-visited (an ancestor). It can't adopt-on-improvement,
+so it falls through to the exhaustion path. At exhaustion it walked the list to
+the **best unprocessed** result, `cliques=25918` (rank 8 — ranks 1–7 were all
+visited), and progressed 8712 → 8713.
+
+Trajectory around it (graph_id : clique_count):
+```
+8704:25915 8705:25918 8706:25913 8707:25923 8708:25915
+8709:25908 8710:25912 8711:25923 8712:25920 8713:25918
+```
+The search has descended **27,401 → ~25,910 since the campaign-10 reseed**
+(~5.4%) but is now **cycling on a plateau ~25,915**: the genuinely-better basin
+(~25,840) is explored-and-blocked, so each stage can only reach marginal novel
+moves, and it burns a full 392M-unit stage to take a ~2-clique step.
+
+### What this tells us
+- Keeping "top-50 **by count**" only survives a visited cluster **shallower than
+  50**. Here it was 7 deep — comfortable, but in a cycling basin the visited
+  cluster *deepens over time*. The day it exceeds 50, the count-only set is
+  all-visited → a true dead-end.
+- The system wastes whole stages grinding to exhaustion when a usable novel
+  improvement already exists in the set.
+
+Tracking **best-novel** instead of **best-by-count** fixes both, and tightening
+the threshold to the best-novel reclaims the u/s slack.
+
+---
+
+## 2. Current design (baseline)
+
+- `best_results:{stageId}` — Redis ZSET, score = clique_count, trimmed to
+  `TOP_RESULTS_COUNT` (currently **50**, set via the shared env var on QM +
+  all workers; middleware does not read it).
+- **Worker** (`worker.rs`, `redis_client.rs`):
+  - Per batch: `get_top_results_threshold(stage, N)` → score at slot **N-1**
+    (the 50th = worst kept). `None` if set has < N entries.
+  - Per unit: `early_limit` derived from threshold → bail (`continue`) if the
+    unit can't beat it. If it qualifies (`count < threshold`), call
+    `add_to_top_results` (Lua: `ZADD` + `ZREMRANGEBYRANK` trim + read back
+    threshold), and tighten the local `top_threshold` from the return.
+- **QM** (`StageProgressionMonitor.java`):
+  - SCENARIO 1 (improvement): checks the single best; if it improves on base
+    **and is novel**, progress immediately. If best is visited → "exhaustion
+    case."
+  - Exhaustion: walk the set for the **first unprocessed** result; progress to
+    it; add its hash to `processed_graph_hashes`.
+  - Visited keyed by `GraphHashUtil.computeDerivedGraphHash(base, edgesToFlip)`
+    = **SHA-256** of the derived edge-data bitstring; membership in the
+    unbounded `processed_graph_hashes` Redis set.
+
+---
+
+## 3. Goal
+
+Make `best_results:{stageId}` hold the **best *novel* graphs**, use the
+**best-novel** as the early-exit threshold, and have all workers learn each
+other's best-novel through that shared set — cheaply.
+
+Outcomes:
+- **Higher u/s:** threshold = best-novel (tightest) and active after the *first*
+  novel result (not the 50th).
+- **No dead-ends:** progression candidate is always novel, regardless of how
+  deep the visited cluster grows.
+- **Early adopt:** progress as soon as a novel improvement appears, instead of
+  grinding to exhaustion.
+- **Simpler QM:** no "walk the list for first unprocessed"; no "improvement but
+  visited" limbo.
+
+---
+
+## 4. Shared-state model
+
+`best_results:{stageId}` stays a ZSET scored by clique_count, contract changed:
+
+- **Novel-only.** A graph enters only if its derived hash is **not** in
+  `processed_graph_hashes` (checked inside the insert Lua — authoritative, no
+  worker-cache skew).
+- **Threshold = slot 0** (global best-novel), not slot N-1. Early-exit bails on
+  anything that can't beat the best-novel → tightest → max u/s; goes active
+  after the **first** novel result.
+- **Trim depth `K = 5`** (down from 50). Slots 1…4 are recent novel
+  record-breakers, kept only as a QM fallback buffer (defense-in-depth).
+
+This is a *small delta* on the existing Lua + a novelty check + a threshold-slot
+change — not a rewrite.
+
+---
+
+## 5. Cross-worker learning — the cadence (the core question)
+
+**Backbone: Lua + re-pull the threshold at batch fetch.** Refinements that make
+it near-optimal without Pub/Sub:
+
+1. **Novelty check inside the insert Lua** (`SISMEMBER processed_graph_hashes`)
+   → the shared set is authoritatively novel; no per-worker visited cache to
+   keep fresh, no skew with the QM.
+2. **Fold the threshold read into the claim Lua** → a batch stays **one
+   round-trip**, not two. The worker learns the global best-novel in the same
+   call it already makes to claim work.
+3. **Free in-batch tightening via the insert Lua's return value** → a worker
+   that's finding improvements self-updates its threshold. Crucially, the
+   workers that *most* need a tight threshold (those finding many near-best
+   graphs) are exactly the ones inserting, so they stay fresh for free. A worker
+   in a "dry spell" is bailing on everything anyway, so its slightly-stale
+   threshold barely matters.
+4. **Optional mid-batch refresh** `THRESHOLD_REFRESH_UNITS` (re-read slot 0
+   every R units). Default off (= fetch size). Lower only if descent-phase A/B
+   shows staleness waste.
+
+**Staleness budget:** batch = 250,000 units; per-worker ~25k–250k u/s → a batch
+is **1–10 s**. So per-batch re-pull = at most ~seconds stale. On a plateau the
+threshold is ~static (free). In fast descent the gap is a few seconds; (3)
+covers the active workers and (4) covers the rest.
+
+**Why not Pub/Sub:** the threshold can only ever be as tight as best-found-so-far
+and moves slowly within a stage; sub-second propagation buys negligible u/s
+while adding an async subscriber + message handling to the hot loop. Revisit
+only if measurement proves staleness is the binding constraint.
+
+---
+
+## 6. The Lua scripts
+
+**Insert** (extends today's `add_to_top_results`) — keys
+`best_results:{stage}`, `processed_graph_hashes`; args `score`, `json`, `hash`,
+`K`:
+```lua
+if redis.call('SISMEMBER', KEYS[2], ARGV[3]) == 1 then
+  return {0, -2}                       -- visited: reject, signal "skip"
+end
+redis.call('ZADD', KEYS[1], ARGV[1], ARGV[2])
+redis.call('ZREMRANGEBYRANK', KEYS[1], ARGV[4], -1)        -- trim to K
+local best = redis.call('ZRANGE', KEYS[1], 0, 0, 'WITHSCORES')  -- slot 0
+return {1, tonumber(best[2])}          -- kept, new best-novel threshold
+```
+Only **qualifying units** (record-breakers under the tight threshold) reach
+this, so the `SISMEMBER` + worker-side hash cost is negligible in aggregate.
+
+**Claim + threshold** (extends `claim_work_range`) — return the work range
+**and** `ZRANGE best_results 0 0 WITHSCORES` in one invocation.
+
+---
+
+## 7. Worker changes (`worker.rs`, `redis_client.rs`)
+
+- `get_top_results_threshold` → read **slot 0**; init `top_threshold` from the
+  claim Lua's returned best-novel.
+- In-loop: early-exit math unchanged, but `top_threshold` is now best-novel. On
+  a qualifying unit: compute the **derived-graph SHA-256** (§9), call the insert
+  Lua; on `kept` update `top_threshold` from the return; on `skip (-2)` just
+  `continue`.
+- Cross-worker freshness: (a) per-batch pull via claim Lua, (b) free tightening
+  via insert returns, (c) optional `THRESHOLD_REFRESH_UNITS`.
+- No local visited-set needed (Lua is authoritative).
+
+---
+
+## 8. QM changes (`StageProgressionMonitor.java`)
+
+- ZSET is now guaranteed novel → **simplify progression**: SCENARIO 1 checks
+  **slot 0**; if `slot0.count < base.count`, **adopt immediately** (folds in the
+  "stop grinding to exhaustion" win — the 8712 case). Exhaustion: take slot 0.
+- **Keep a defensive re-verify**: re-run `isGraphAlreadyProcessed` on the chosen
+  graph; on the rare miss fall to slot 1…K-1. This makes the worker hash a pure
+  *optimization* — if it's ever wrong, the system degrades to correct-but-slower,
+  never incorrect.
+- `processed_graph_hashes` ownership unchanged (QM adds on progression).
+
+---
+
+## 9. Hash decision — KEEP SHA-256
+
+The visited key stays **SHA-256** of the derived edge-data bitstring (matching
+`GraphHashUtil`). Rationale:
+
+- **It's not on the hot path.** We hash only record-breakers (dozens–hundreds
+  per stage), not the 392M units. At ~30 µs each that's single-digit ms/stage —
+  optimizing it buys nothing. (If we ever hashed *every* unit it'd be ~hours/
+  stage and we'd need both a faster hash and a cheaper input — but the tight
+  threshold design specifically avoids that.)
+- **Free cross-language byte-identical agreement.** Worker (Rust) and QM (Java)
+  must emit identical digests or cycle-prevention silently breaks. SHA-256 is a
+  rigid spec; every impl matches. A non-crypto hash (XXH3/wyhash) *can* match
+  but only with pinned variant/seed/endianness — easy to get subtly wrong, for a
+  speed win we don't need.
+- **Effectively zero collision risk.** A collision = a novel graph silently
+  flagged visited and skipped — possibly the solution graph. 256 bits makes that
+  impractical; a 64-bit hash's ~10⁻⁶ lifetime risk is needless here.
+
+**If** hashing ever profiles hot, the right lever is feeding SHA-256 the
+**packed bits (~5 KB)** instead of the 39,621-char `'0'/'1'` string (~8× less
+data, still cross-language-safe) — not a weaker algorithm. Either change
+requires re-seeding `processed_graph_hashes` (QM supports reseed-from-MySQL), so
+it's a coordinated migration, not a drop-in.
+
+### Hash parity (required before rollout)
+Worker must reproduce `computeDerivedGraphHash` byte-for-byte: take base
+`edge_data`, flip the unit's edges at upper-triangular index
+`v1*(n-1) − v1*(v1+1)/2 + v2 − 1`, SHA-256 the UTF-8 `'0'/'1'` string,
+lowercase-hex. **Deliverable: a shared test vector** (fixed graph + fixed flips,
+assert Rust digest == Java digest) checked into both repos and run in CI. A
+mismatch makes everything "look novel" — caught by the QM re-verify (graceful)
+but it kills the benefit, so gate rollout on this test.
+
+---
+
+## 10. Config
+
+- `TOP_RESULTS_COUNT`: **50 → 5** (shared env var; worker trim depth + threshold
+  buffer, QM fallback depth — keep equal as today).
+- New optional `THRESHOLD_REFRESH_UNITS` (worker), default = fetch size (off).
+
+---
+
+## 11. Rollout
+
+- Semantic change to **shared Redis state** → deploy **QM + all workers
+  together**, ideally at a stage boundary. Mixed old/new workers would let old
+  workers insert visited graphs — tolerable (QM re-verify) but avoid.
+- Surgical Portainer deploy (pre-pull images, `pullImage=false`), confirm at a
+  fresh stage. **Never push compose to Portainer without explicit confirmation.**
+
+---
+
+## 12. Validation & measurement
+
+- **Offline first:** extend the `single-flip-check` pilot harness to replay a
+  real stage's work against the new threshold/novelty logic and confirm it picks
+  the same progression graph the live QM did (e.g. reproduce 8712 → 25918) with
+  the visited filter active.
+- **Hash vectors** (§9) green in CI.
+- **A/B live:** the metric is **stage wall-clock + best-clique trajectory**, NOT
+  raw u/s. Expect (i) higher early-stage u/s, (ii) shorter stages in
+  visited-heavy regions via early-adopt, (iii) no dead-ends as visited clusters
+  deepen.
+
+---
+
+## 13. Risks & mitigations
+
+- **Plateau / escape moves (the current regime!).** When no novel move beats
+  base, the ZSET naturally starts empty → `None` → full-count until the first
+  novel (uphill) result, then tightens to the least-uphill novels. Escape moves
+  are preserved **as long as you don't aggressively seed** the threshold below
+  where they live. So **do not** seed the stage-start threshold to `base − 0`;
+  keep the natural None→tighten behavior (or seed `base + margin` only if you
+  later add seeding — see Future).
+- **Hash skew:** QM re-verify (§8) → graceful degradation.
+- **Buffer too small:** `K=5` + re-verify; bump K if logs show re-verify walking
+  past slot 0.
+
+---
+
+## 14. Phasing
+
+- **Phase 0 (optional, hours):** QM-only early-adopt — make SCENARIO 1 walk the
+  top-N for the best *novel* improvement (what exhaustion already does). Pure QM,
+  reversible, kills the exhaustion-grind immediately; de-risks before touching
+  workers.
+- **Phase 1:** hash parity (Rust impl + shared test vector in CI).
+- **Phase 2:** insert Lua + claim Lua + worker threshold=slot0 + `K=5`; QM
+  simplification + re-verify.
+- **Phase 3:** deploy QM + workers together at a stage boundary; A/B; then tune
+  `THRESHOLD_REFRESH_UNITS` only if descent-phase staleness shows up.
+
+---
+
+## 15. Future / open questions
+
+- **Stage-start threshold seed.** Seeding from base count would kill the slow
+  opening entirely, but breaks plateau escape unless seeded with an uphill
+  margin. Defer until the descent regime (not plateau) is the common case, or
+  make the margin adaptive.
+- **Hashing the packed bits** (§9) if hashing ever profiles hot.
+- **The strategic problem is the plateau, not the engine.** This plan makes the
+  existing single/double-flip descent *faster and more robust*; it does not
+  escape the ~25,9xx local-minimum basin. That needs a different move class
+  (multi-vertex / construction-path), tracked elsewhere.

--- a/docs/investigations/engine-optimization-review.md
+++ b/docs/investigations/engine-optimization-review.md
@@ -55,7 +55,11 @@ Cardinality and participation correlate, and the June 10 census warned that impr
 
 ### 7. Strategic layer (unchanged, for when this vein thins)
 
-Recent stage gaps are lengthening (~1.5h sweeps reappearing within the first day) — the wall will reform at some deeper count. The documented next move spaces remain: **vertex-row re-optimization** (per-vertex 2^281 neighborhoods on existing primitives; subsumes all single flips), **windowed MaxSAT** (optimal multi-edge moves; `sat-solver-investigation.md` Tier 2), and **same-color pairs** (requires handling the seeded-BK double-count documented by `same_color_seed_pairs_count_shared_cliques_twice` in the worker regression suite).
+Recent stage gaps are lengthening (~1.5h sweeps reappearing within the first day) — the wall will reform at some deeper count. The documented next move spaces:
+
+- **Vertex-row re-optimization** — ⛔ INVESTIGATED & RESOLVED 2026-06-13 (`row-optimization-investigation.md`): a full 282-vertex sweep of the best graph (8348, 775,642) found **zero** improving rows. The entire single-vertex-star move class (all single flips, all within-star pairs, all-depth single-row rewrites) is exhausted on this lineage. The graph is **row-locked**; this is not the way forward at 775,642.
+- **Windowed MaxSAT** (optimal multi-edge moves; `sat-solver-investigation.md` Tier 2) — now the leading candidate, since the row-lock result says improving moves must be genuinely multi-vertex. Direct next rung: **2-vertex joint re-optimization** (the 2-vertex window, generalizing the validated row-opt tooling).
+- **Same-color pairs** (requires handling the seeded-BK double-count documented by `same_color_seed_pairs_count_shared_cliques_twice` in the worker regression suite) — note that *within-star* same-color pairs are already covered (and found empty) by the row sweep; only *cross-star* same-color pairs remain unexplored here.
 
 ---
 

--- a/docs/investigations/joint-reoptimization-investigation.md
+++ b/docs/investigations/joint-reoptimization-investigation.md
@@ -1,0 +1,74 @@
+# 2-Vertex Joint Re-Optimization — Investigation
+
+**Date:** 2026-06-13
+**Author:** Ben Ferenchak + Claude
+**Status: NO HIT on graph 8348 (campaign 2 best, 775,642) — robustly firmed.** A validated 2-vertex joint optimizer found zero improvement across **214 vertex pairs**: 14 targeted (6 lowest-coupling/"marginal", 8 highest-coupling) plus a 200-pair uniform-random firming sweep. Rule of three puts the improvable-pair fraction under ~1.5%. This is the next rung above the row-lock result — **strong evidence (a large sample, though not the exhaustive certainty of the row sweep)** that small-window local moves do not break this wall. Next: strategic reset / diversification (multi-seed).
+
+**Related documents:**
+- `row-optimization-investigation.md` — the 1-vertex window; resolved row-locked. This is the 2-vertex window.
+- `sat-solver-investigation.md` — windowed/local MaxSAT (Tier 2); the k-vertex generalization, the natural escalation from here.
+- `engine-optimization-review.md` §7 — strategic layer.
+- Tools/data: `single-flip-check/src/bin/joint_pilot.rs`, `pair_coupling.rs`, `clique_census.rs`; logs in `/tmp/joint_*.log`.
+
+---
+
+## What the joint move is
+
+Re-optimize TWO vertices' rows (and the edge between them) simultaneously. Against the fixed graph G−{u,v}, every mono 8-clique through u or v decomposes into:
+- **single-star** (through one vertex): that vertex + a mono 7-clique of G−{u,v}, fully colored by its row — one clause per mono 7-clique, over u's row block (`a`) and over v's row block (`b`). Width 7.
+- **joint** (through both): {u,v} + a mono 6-clique S of G−{u,v}, with the u–v edge `e` and u,v's 6+6 connections to S all the clause color — one clause per mono 6-clique. Width 13.
+
+f = violated clauses = cliques through u **or** v; total = const + f (exact). The edge `e` (in every joint clause) is handled by a 2-iteration outer loop (e=red, e=blue): with e fixed, only that color's joint clauses can fire, and e is a constant-satisfied literal — so the inner problem is a variable-width weighted-MaxSAT over the 2·(n−2) row bits, solved by the same incremental-counter + SATLike engine validated for row-opt.
+
+This reaches **coordinated cross-star rewrites** expressible by neither the production engine nor single-vertex row-opt: it can move both rows together through configurations where any single-row change worsens the count but the joint change improves it.
+
+## Tooling and validation (all PASS)
+
+`joint_pilot.rs` (one-off crate, no repo/system interaction). Feasibility from `clique_census.rs`: graph 8348 has 8.88M mono 7-cliques and **25.5M mono 6-cliques** → a per-pair DB of ~8.4M single-star + ~24.4M joint ≈ 29M clauses, ~2.3 s build. Validation:
+- **Anchor** (n=11, k=4): brute-forced the entire joint assignment space; search reaches the true optimum (all 4 cliques through the pair eliminated), spliced recount exact.
+- **Counters at 282v** (pair 159,179): f(incumbent) = 41,813 = independent through-pair clique enumeration; **40 random assignments every one matched a from-scratch brute clique count**. The 29M-clause incremental machinery is provably correct.
+
+## Results — 0 improvements across 14 pairs
+
+Seed strategy 1, **marginal pairs** (the 4 vertices where row-opt's best single flip was only +2: 159, 179, 187, 29 → all 6 pairs), 180 s/edge-color:
+
+| pair | through-both (coupling) | f₀ | best delta |
+|---|---|---|---|
+| all 6 pairs | ~200 (LOW — below median 534) | 41.8–43.8K | **0** |
+
+Seed strategy 2, **highest-coupling pairs** (most shared 8-cliques, via `pair_coupling.rs`), 180 s/edge-color:
+
+| pair | shared cliques | f₀ | best delta |
+|---|---|---|---|
+| (25,111) | 1385 | 44,294 | 0 |
+| (171,185) | 1353 | 44,296 | 0 |
+| (49,110) | 1335 | 43,212 | 0 |
+| (203,253) | 1316 | 42,509 | 0 |
+| (162,216) | 1313 | 42,890 | 0 |
+| (51,205) | 1308 | 42,555 | 0 |
+| (47,220) | 1302 | 42,399 | 0 |
+| (125,227) | 1298 | 43,868 | 0 |
+
+**Total: 0 / 14 pairs improved.** Every pair, both edge colors, ~183–189K SATLike moves: nothing below the incumbent. Two structural observations:
+- **Greedy from the incumbent made 0 improving steps** on the incumbent edge color for all 14 pairs — not even a single coordinated bit-flip improves.
+- **Flipping the edge always worsened** the count (start_f rose), and greedy from there never recovered below the incumbent. The two stars are jointly at a strict local optimum at every tested pair.
+
+### Firming sweep — 200 random pairs (2026-06-13)
+
+The 14 targeted pairs bracket the coupling extremes (low/marginal and highest); to cover the broad middle and firm the negative, a uniform-random sample of **200 distinct pairs** (4 parallel shards, 60 s/edge-color, `joint_pilot sample` mode) was run. Result: **0 / 200 improved**, no nonzero deltas anywhere, sampled incumbent objectives spanning start_f 41,765–46,255 (a wide coupling spread). Combined total: **0 of 214 pairs**.
+
+Rule of three: 0 events in 200 random trials → 95% upper bound ≈ 3/200 = **1.5%** of pairs improvable. At most ~600 of 39,621 pairs could improve, and those would have to be neither the highest-coupling, nor the marginal, nor anywhere in the random middle — a shrinking and implausible hiding spot. The 2-vertex-joint move is **robustly locked** on graph 8348.
+
+## Honest scope
+
+This is still a **sample, not an exhaustive sweep** (214 of 39,621 pairs; the row sweep was exhaustive over all 282 vertices). It is not a proof that *no* pair improves. But three independent seed strategies — closest-to-improving-as-singles, highest-coordination, and uniform-random — all came up empty with the same strict-local-optimum signature (greedy makes 0 improving steps; the edge flip only worsens). A full pair sweep is impractical by hand (~39.6K pairs × ~minutes ≈ weeks serial). The negative is now firm enough to act on.
+
+## Verdict and recommendation
+
+Across graph 8348 every efficiently-searchable local move shape is now empty: all single flips (engine + census), all within-star pairs and all-depth single-row rewrites (exhaustive row sweep), and 2-vertex joint moves across 214 pairs (targeted + random). The 775,642 wall is exceptionally robust to local search — consistent with SA, tabu, and VDS having walled out earlier on this lineage.
+
+Two forward paths:
+1. **k-vertex windowed MaxSAT** (`sat-solver-investigation.md` Tier 2) — the documented next rung: exactly/near-exactly solve windows of 3+ vertices. Qualitatively stronger than local search, but each rung costs more (window selection over C(282,k); larger per-window solves) and the prior two rungs (1- and 2-vertex) found nothing — diminishing-returns bet.
+2. **Strategic reset / diversification** — accept 775,642 as a deep local floor for the Paley(281)+1 seed and diversify: multiple independent descents from different seeds, aggressive restarts, or a structurally different construction. The accumulated negative evidence (every local method walls out here) now favors this read.
+
+The validated `joint_pilot` tooling is reusable on future best graphs (re-run `pair_coupling` + `joint_pilot` when a new wall forms). Do not build production integration of the joint move without a hit first.

--- a/docs/investigations/paley-graph-investigation.md
+++ b/docs/investigations/paley-graph-investigation.md
@@ -95,6 +95,32 @@ This is referenced as a structural comparison: another self-complementary algebr
 
 ---
 
+## UPDATE 2026-06-14 — The optimized single-vertex extension is ~27K, not 100M (and 28× better than the campaign)
+
+The "100M+" figure above is a **counting error** (likely non-maximal overcount or a bug): every 8-clique in a one-vertex extension must contain the new vertex and corresponds to a distinct mono 7-clique of Paley(281) that the new vertex monochromatically completes, so the count is **bounded by 5,979,680** (the mono-7-clique total) and is far lower for any reasonable row. Measured directly (tool `single-flip-check/src/bin/paley_gen.rs` + `clique_census.rs`, generator validated: it reproduces Paley(281)'s exact 5,979,680 mono-7 / 0 mono-8 counts):
+
+- **A random extension has only ~44,000 mono 8-cliques** (seed 1: 44,062), matching the doc's own naive estimate (~23K per color), not 100M.
+- **Row-optimizing just the new vertex against fixed Paley(281)** (validated `rowopt_pilot vertex`, the MaxSAT local-search the original direct-SAT attempt lacked) drops it to **~27,401** (8 random starts: 27,401–28,815, all recount-verified). All cliques are through the new vertex; Paley(281) is left intact.
+
+**The headline comparison:** a few minutes of "extend Paley(281) optimally" yields a 282-vertex graph with **27,401** mono 8-cliques — versus **775,623** after two months and 2,431 stages of the full-mutation campaign (which started at 817,828 and descended only ~5%). The campaign's mutate-all-edges strategy destroyed Paley's structure and wandered ~28× higher than the construction it started from. **The search has been running in the wrong region.**
+
+Caveats: (1) ~27K is a robust local-min band for single-vertex row-opt, not zero — reaching zero (R(8,8) ≥ 283) is not achieved this way and remains open. (2) Reducing below ~27K requires mutating Paley(281)'s own edges, which risks the documented avalanche. (3) But as a **seed**, 27K dominates 775K by the objective.
+
+### Descent probe — the 27K seed is a deep LOCKED minimum (avalanche confirmed)
+
+To test whether 27K is exploitable (descends toward 0) or a narrow well (blows up), a row-opt sweep was run on a sample of the 27K graph's vertices (0, 40, 80, 120, 160, 200, 240, 280, 281):
+
+- **All 8 sampled Paley vertices (0–280) are row-locked** — re-optimizing any of their rows yields zero improvement (delta 0, distance 0), and **their best single edge flip *worsens* the count by +170 to +605** (avalanche signature: touching Paley's knife's-edge structure explodes cliques).
+- Only the **new vertex (281)** has any give, and it is near its floor — a fresh row-opt squeezed 27,401 → 27,085 (−316) once via SATLike but greedy reproduces no further gain. The descent is confined to the new vertex's row and is essentially exhausted at ~27K.
+
+**Conclusion: the Paley(281)+optimized-vertex graph (~27K) is a deep, strict local minimum — the same fundamental wall as the campaign's 775K graph, just 28× lower.** Local edge-flip search caps out at both. Re-seeding the campaign here would bank a 28× better best-known floor but would *not* descend toward zero (the engine's singles/pairs would lock immediately, as on graph 8348). Reaching zero (R(8,8) ≥ 283) is not accessible by local search from either basin; it would require a base construction with fewer mono-7-cliques than Paley(281) while keeping zero mono-8-cliques (open/hard), or exact methods (infeasible at 5.98M-clause scale).
+
+### Reseed outcome (2026-06-14) — the construction seed DESCENDS via balanced pairs
+
+Acting on the finding, campaign 2 (775,642) was retired and a **new campaign (id 10) was seeded from the 27,401 graph** (`single-flip-check/results/paley282_opt.txt`): all workers + QM stopped, graph 8389 / campaign 10 / stage 8389 inserted, campaign 2 set INACTIVE, `RAMSEY_CAMPAIGN_ID` 2→10 in compose, Portainer stack 7 redeployed. The QM seeded Redis from the graph (worker `total_pairs` guard passed); 14 workers + QM came up clean.
+
+**The engine descends from the 27K seed** — 27,401 → 27,390 → 27,339 → … → 27,214 in the first ~6 minutes, ~30 s/advance, genuine improvements. This refines the descent-probe conclusion: the probe only tested *row rewrites* and *single flips* (both locked, avalanche), but the production engine's **balanced-pair** moves (one red→blue + one blue→red, preserving balance) were never probed and they descend freely. So the construction reseed *worked*: it dropped the active search ~28× below campaign 2 and into a productive basin. Where it plateaus is the new open question (a deeper wall will presumably reform; the local-search ceiling characterization above still applies — reaching zero still needs a better base than Paley(281) or exact methods).
+
 ## Implications for Search Direction
 
 1. **Paley(281) is the natural seed**, not a competitor. Adding a vertex is the actual problem.

--- a/docs/investigations/row-optimization-investigation.md
+++ b/docs/investigations/row-optimization-investigation.md
@@ -1,0 +1,114 @@
+# Vertex-Row Re-Optimization — Investigation
+
+**Date:** 2026-06-12 (pilot) → 2026-06-13 (full sweep)
+**Author:** Ben Ferenchak + Claude
+**Status: RESOLVED 2026-06-13 — graph 8348 (campaign 2 best, 775,642 cliques) is ROW-LOCKED.** A full 282-vertex sweep found zero improving rows. The single-vertex move class is exhausted on this lineage; the next productive move space must be multi-vertex. **Do not re-run the sweep on graph 8348.** The tool is validated and reusable on *future* best graphs when a deeper wall forms.
+
+**Related documents:**
+- `sat-solver-investigation.md` — windowed/local MaxSAT (Tier 2); row-opt is its degenerate 1-vertex window, and this result motivates widening it
+- `engine-optimization-review.md` — strategic layer §7 listed row-opt as the next move space; this note resolves it
+- `deep-analysis-path-forward.md` / `may-2026-next-steps.md` — strategic roadmap
+- One-off tool & data: `single-flip-check/src/bin/rowopt_pilot.rs`, inputs/logs in `single-flip-check/results/`
+
+---
+
+## TL;DR — what was tried and why we should not repeat it
+
+We asked, for the current best graph: **can re-choosing any single vertex's entire 281-bit row reduce the monochromatic 8-clique count?** This is a 2^281 neighborhood per vertex that *subsumes* every single edge flip and every within-star edge pair (same-color pairs included — which the production engine never searches), plus arbitrary-depth coordinated rewrites of one vertex's star.
+
+Answer on graph 8348: **no, for all 282 vertices.** Not one vertex has even a *neutral* single flip, and ~134K SATLike moves per vertex found nothing better at any depth. The graph is a strict, deep, single-vertex-star local minimum — fully consistent with the live engine advancing only +2 per stage by exhaustion fallback.
+
+**Operational takeaways:**
+1. Don't expect singles, within-star pairs, or single-row rewrites to break the 775,642 wall — that entire class is empty here.
+2. Don't re-run the sweep on 8348; the answer won't change without a longer budget than is justified.
+3. The next move space is genuinely **multi-vertex** (2-vertex joint re-optimization → windowed MaxSAT). See "Strategic implication" below.
+4. The tool is correct and fast (~1.1 s clause build/vertex); **re-run it on the new best graph if a deeper wall ever forms.**
+
+---
+
+## The formulation (exact, validated)
+
+Fix a vertex v. Every monochromatic 8-clique through v is exactly a monochromatic 7-clique in G−v whose seven vertices are *all* colored the clique's color by v's row. The other 281 vertices' mutual edges are untouched when v's row is rewritten, so for vertex v:
+
+- The clause set is **static**: one clause per mono 7-clique of G−v (~8.66M clauses at 282v), each tagged red or blue.
+- `f(row)` = number of violated clauses = mono 8-cliques through v. **Total cliques = (cliques avoiding v, a constant) + f(row)** — an *exact* objective, not a heuristic.
+- The incumbent row is a known-good warm start (~21–24K violations out of ~8.66M).
+
+This is the **1-vertex window** of local MaxSAT. It's also the classic "one-vertex extension" move from Ramsey lower-bound constructions, applied to the evolved core.
+
+## The tool
+
+`single-flip-check/src/bin/rowopt_pilot.rs` (one-off crate, path-dep on the worker crate; **not in any production repo**). Modes:
+
+- `paley17` — correctness anchor (below).
+- `known <stages_tsv> <stage_from> [budget_s]` — recover a known historical answer.
+- `vertex <bits_file> <n> <k> <v,v,...> [budget_s]` — merit/sweep scan.
+
+Per vertex: build static clause DB → exact incremental match-counters with make/break bookkeeping → greedy best-bit descent → SATLike (WalkSAT over violated clauses with additive clause weighting, WP=0.15) from the incumbent plus two perturbed restarts (Hamming 8 and 32). Any reported improvement is re-validated by a from-scratch Bron-Kerbosch recount of the spliced full graph before being believed. ~1.1 s build, ~134K moves in a 120 s budget, ~420 MB/vertex.
+
+---
+
+## Phase 1 — Pilot (2026-06-12): machinery validated, merit signal mixed
+
+Three layers, each against ground truth. **All PASS.**
+
+1. **Paley(17) anchor.** Damaged Paley(17) (R(4,4)-extremal), row-opt one vertex, and brute-forced all 2^16 candidate rows: the optimizer reached the true exhaustive optimum. Clause reduction matched brute-force mono-K4 counts on 150 random rows.
+2. **Known-answer recovery (campaign 1, 288v), 3/3.** Three historical within-star wins reproduced exactly by the counters *and* rediscovered by search, with exact spliced recounts:
+   - stage 3273→3274, vertex 204, **−213**
+   - stage 1639→1640, vertex 229, **−181** — found even though **every** single flip at that star worsens (best +5); proves the search punches through singles-locked landscapes.
+   - stage 146→147, vertex 2, **−178**
+   Corollary: 3273/146 were reachable as two chained greedy singles — campaign 1's within-star pair wins were largely chained singles, and campaign 1 never searched singles at all.
+3. **Stage 8319 merit scan (10 stars × 120 s).** All four known census singles rediscovered from both endpoints (−4/−4/−3/−2; recounts hit 775,838/839/840 exactly — 775,838 = stage 8320's real production value). The hot-edge stars (v53/v167, all singles ≥ +10) found nothing. **No depth-≥2 win surfaced** on the ten tested stars.
+
+Pilot verdict: the tool is exact and capable; the unique value of row-opt over production (same-color within-star pairs + depth ≥3) was *unproven* on 8319's sample — motivating the full sweep on the *current* best graph.
+
+## Phase 2 — Full sweep (2026-06-13): graph 8348 is row-locked
+
+**Why 8348:** the campaign 2 wall re-formed at **775,642** cliques (graph 8348, found 2026-06-12 19:10 UTC). Stages 8349–8351 then advanced only +2 each (~95 min apart) by exhaustion fallback — full `DUAL_EDGE_CARDINALITY_WITH_SINGLES` sweeps (both-color singles + ~392M red×blue pairs) finding zero genuine improvements.
+
+**Run:** `rowopt_pilot vertex graph_8348_edge_data.txt 282 8 0..281 120`, all 282 vertices, 120 s each, serial, ~9.4 h wall clock under `caffeinate`. Input = MySQL `graph_id` 8348.
+
+### Results
+
+| Metric | Value |
+|---|---|
+| Vertices swept | 282 / 282 |
+| Improvements found | **0** |
+| Best improvement | none — every vertex stayed at its incumbent row (distance 0) |
+| Base enumeration | 775,642 (matches MySQL graph 8348) |
+| Clause DB per vertex | ~8.66M mono 7-cliques, 1.1 s build |
+| SATLike moves per vertex | mean 134,488 (min 128,048, max 145,184) |
+| **Verdict** | **Row-locked** — no single-vertex row rewrite, at any depth, reduces the count within budget |
+
+### Validation gates — all held
+
+- **Base count** = 775,642, exactly matching MySQL `graph_id` 8348.
+- **Cross-check invariant:** per-vertex incumbent counts (cliques through v) sum to **6,205,136 = exactly 8 × 775,642**. Each 8-clique is counted once through each of its 8 vertices, so this independently confirms all 282 clause databases were built correctly — every per-vertex reduction, not just the total.
+- **No spurious improvements:** zero; the search never beat any incumbent, so no recounts were triggered.
+
+### How deep the basin is
+
+- **Not one vertex has an improving single-bit move.** Best single-bit flip across all 282 vertices: min **+2** (worsens), median +48, mean +49, max +118. Zero vertices have even a *neutral* (delta-0) single bit.
+- **No deeper single-star rewrite helps.** ~134K SATLike moves/vertex with clause weighting and two perturbed restarts; every run returned to (or never left) the incumbent. Calibration: the pilot's hardest known positive (stage 1639's −181, through an all-worsening-singles landscape) was found in **52,800 moves** — here 2.5× that budget found nothing, uniformly across all 282 vertices.
+- **Most marginal stars** (best single +2): vertices **159, 179, 187, 29** — natural seeds for the next move space.
+
+### Interpretation
+
+The single-flip + both-color-singles + balanced-pair engine has driven campaign 2 into a basin where the **entire single-vertex-star move class is exhausted**: every single flip, every within-star pair (same-color included), and every arbitrary-depth rewrite of one vertex's 281-bit row. This matches the live engine exactly (stages 8349–8351, +2 by exhaustion only).
+
+**Honest caveat:** local search cannot *certify* optimality — 2^281 per vertex is uncountable and 134K samples is a vanishing fraction. But the budget was calibrated against a known-hard positive, the result is uniform across all 282 vertices, and it converges with independent evidence (the production engine is equally stuck). "Row-locked" is the correct operational conclusion, not a proof of optimality.
+
+---
+
+## Strategic implication — widen the window
+
+Row-opt is the 1-vertex window of local MaxSAT. The clean sweep says that window is empty here, so the next productive move space must be **genuinely multi-vertex** — coordinated rewrites spanning two or more stars *simultaneously*, which neither the production engine nor row-opt can reach. Direct next rung:
+
+- **2-vertex joint re-optimization** — ✅ DONE 2026-06-13 (`joint-reoptimization-investigation.md`): the 2-vertex window was built, validated, and run on 14 best-seeded pairs (marginal + highest-coupling). **0 hits.** Not exhaustive (14 of 39,621 pairs), but both principled seed strategies came up empty with the same strict-local-optimum signature.
+- **windowed MaxSAT** proper (`sat-solver-investigation.md` Tier 2): k-vertex windows solved exactly/near-exactly — the remaining algorithmic rung, now with 1- and 2-vertex windows both empty below it (diminishing-returns bet).
+
+This investigation converts "campaign 2 is probably stuck" into "campaign 2 is **row-locked at 775,642**"; the follow-on joint investigation extends that to 2-vertex windows. With every small-window local move empty, the live strategic question is **escalate to windowed MaxSAT vs. diversify the search (multi-seed / different construction)** — see the joint doc's verdict.
+
+## When to reuse this tool
+
+Re-run the `vertex` mode sweep on the **then-current best graph** whenever a new, deeper wall forms (export the best graph's `edge_data` from MySQL, point the tool at it). It's cheap (~1.1 s build/vertex; ~9.4 h serial at 120 s/vertex, or far less with across-vertex parallelism or a shorter budget). A future graph with different structure could have an improvable row even though 8348 does not. Do **not** build production integration of row-opt unless a sweep actually finds a hit; injection of any hit would go through the manual stage-seed path (MySQL graph+stage insert, Redis re-seed, **fleet restart** — see the stale-config ops lesson in the 2-flip-wall notes).

--- a/docs/investigations/search-status-2026-06-14.md
+++ b/docs/investigations/search-status-2026-06-14.md
@@ -1,0 +1,60 @@
+# Search Status & Findings — June 2026 (consolidated)
+
+**Date:** 2026-06-14
+**Author:** Ben Ferenchak + Claude
+**Purpose:** Single entry-point summary of the June 9–14 investigation campaign. Read this first; it points to the detailed docs and lists what is settled and what NOT to retry. Goal throughout: a 282-vertex 2-coloring with zero monochromatic 8-cliques (would prove **R(8,8) ≥ 283**).
+
+---
+
+## Current state (as of 2026-06-14)
+
+- **Active campaign: 10** (created 2026-06-14), seeded from **Paley(281) + one row-optimized vertex = 27,401 mono-8-cliques**. Fast descent via balanced-pair moves to **27,058 (−343 in ~10 min), then re-walled** there (confirmed plateau ~22:30Z; exhaustion-advancing to slightly-worse graphs). Best-known 282-graph is now **27,058**, ~28.6× below campaign 2. Campaign left running (may grind slowly lower via exhaustion-fallback over hours, as campaign 2's tail did).
+- **Campaign 2 (best 775,642) is RETIRED / INACTIVE.** It had wandered into a generic local-minimum basin ~28× worse than the construction it started from. Preserved in the DB (reversible) but no longer the search.
+- **Best-known 282-graph is now the campaign-10 lineage (~27K and dropping)**, not 775,642. The verified seed graph is saved at `single-flip-check/results/paley282_opt.txt`.
+
+## The headline finding
+
+**A few minutes of "extend Paley(281) optimally" beat two months of full-mutation descent by ~28×.**
+- Paley(281) (281 vertices) is monochromatic-8-clique-free — the standard proof R(8,8) ≥ 282. The entire 282-vertex problem is *how to add the 282nd vertex*.
+- Campaign 2's strategy (random extension, then mutate **all** edges) destroyed Paley's structure and only descended ~5% (817,828 → 775,642) before locking.
+- Keeping Paley(281) **fixed** and row-optimizing only the new vertex's 281-bit row yields **~27,401** mono-8-cliques (8 random starts: 27.4–28.8K, recount-verified). Re-seeding the live search here dropped it 28× and it descends.
+- Detail + the corrected "100M+ → ~44K random / ~27K optimized" counting error: `paley-graph-investigation.md`.
+
+## What is settled — and what NOT to retry
+
+Everything below was established with validated, cross-checked tooling (every clique enumeration matched independent counts). **Do not re-run these:**
+
+1. **Campaign 2's wall graph (8348, 775,642) is locked against every efficiently-searchable local move:**
+   - all single edge flips (engine sweeps + the June-10 census) — `engine-optimization-review.md`
+   - all within-star pairs and all-depth single-row rewrites — **exhaustive 282-vertex row sweep, 0/282** — `row-optimization-investigation.md`
+   - 2-vertex joint moves — **0/214 pairs** (marginal + highest-coupling + 200 random; rule-of-three < 1.5%) — `joint-reoptimization-investigation.md`
+2. **Participation-ordered enumeration: REJECTED** (campaign-1 backtest, winners uniform in participation rank). Keep `DUAL_EDGE_CARDINALITY`. A *learned* ranker is the only credible ordering upgrade (needs result logging, still off). — `engine-optimization-review.md`
+3. **Simulated annealing, tabu+clique-guided, VDS: all RETIRED** (each: tens of thousands to millions of iterations, zero improvements). — `simulated-annealing-investigation.md`, `tabu-search-investigation.md`, `vds-enhancements.md`
+4. **Do not restart/continue campaign 2.** It is a wandered dead basin dominated 28× by the campaign-10 construction.
+5. **Do not trust the legacy "Paley(281)+1 = 100M+ cliques" claim** — that was a counting error; a random extension is ~44K, an optimized one ~27K.
+6. **Do not conclude the 27K seed is "locked" from the row-opt/single-flip probe.** Those moves avalanche (+170 to +605), but the engine's *balanced-pair* moves descend — proven live by campaign 10.
+
+## Tooling (one-off crate `single-flip-check/`, NOT in any product repo; all validated, reusable)
+
+| Binary | Purpose |
+|---|---|
+| `clique_census.rs` | u64 mono-k-clique counts (validated vs Paley(281)'s known totals) |
+| `paley_gen.rs` | generate Paley(p) / Paley(p)+vertex bitstrings (reproduces Paley(281) exactly) |
+| `rowopt_pilot.rs` | single-vertex row re-optimization (MaxSAT local search); `ROWOPT_SAVE` env writes the optimized graph |
+| `joint_pilot.rs` | 2-vertex joint re-optimization (`anchor`/`counters`/`pair`/`seed`/`sample` modes) |
+| `pair_coupling.rs` | rank vertex pairs by shared 8-cliques (joint seeding) |
+| `campaign1_ordering_backtest.rs`, `star_enrichment.rs` | participation-ordering backtest, star-enrichment scan |
+
+Reuse pattern: when a new wall forms on the active best graph, export its `edge_data` from MySQL and re-run the relevant tool. Re-seeding production = stop workers+QM, insert graph/campaign/stage, set old campaign INACTIVE, change `RAMSEY_CAMPAIGN_ID` in compose, redeploy stack 7 (env-only). The QM seeds Redis from the graph; the worker `total_pairs` guard enforces lockstep.
+
+## Open problems / candidate future directions
+
+- **Reaching zero (R(8,8) ≥ 283) is still open.** Local edge-flip search caps at deep minima far from zero (775K wandered; ~27K constructed — and even 27K is row-locked, only pair-descendable). Getting near zero would need either a **base construction with fewer mono-7-cliques than Paley(281) while keeping zero mono-8** (hard/open), or **exact methods** (infeasible at ~6M-clause scale).
+- **Where campaign 10 plateaus** is the immediate unknown (under monitoring 2026-06-14).
+- **k-vertex windowed MaxSAT** (`sat-solver-investigation.md` Tier 2) — the next move-shape rung, but 1- and 2-vertex windows are both empty, so diminishing returns.
+- **Result logging (Tier 3.0)** is still off — it gates any learned enumeration ordering.
+- **Cheap config wins** (worker `WORK_UNIT_FETCH_COUNT` 250K→50K, `EXHAUSTION_DELAY_MS` 60→15s, `CYCLE_PREVENTION_GRAPH_LOOKBACK_COUNT` 50→200, pin Dragonfly off `:latest`) are documented and staged but **not yet shipped**. — `engine-optimization-review.md`
+
+---
+
+*Generated for the Ramsey project — 2026-06-14. Supersedes the strategic framing in `engine-optimization-review.md` §7 and `deep-analysis-path-forward.md` where they differ.*


### PR DESCRIPTION
Adds research/investigation docs accumulated over recent sessions and updates two existing ones. Documentation only — no code or config.

- **best-novel-threshold-plan.md** — Option B (novel-only best-results cache); now SHIPPED.
- **joint-reoptimization-investigation.md**, **row-optimization-investigation.md** — 2-vertex joint + single-vertex row-opt diagnostics (both basins locked).
- **search-status-2026-06-14.md** — consolidated status entry-point.
- updates to **engine-optimization-review.md** and **paley-graph-investigation.md**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)