### PR TITLE
Point ramsey-ui compose service at port 8080

### DIFF
--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -229,7 +229,7 @@ services:
     networks:
       - ramsey-net
     ports:
-      - "36003:8501"
+      - "36003:8080"
     environment:
       API_BASE_URL: http://ramsey-mw:8080
       REDIS_HOST: redis


### PR DESCRIPTION
Companion to benfff85/ramsey-ui#13. The Streamlit UI (container `:8501`) is replaced by the React + Spring Boot `ramsey-ui`, which listens on `:8080`. Updates the `ramsey-ui` service port mapping in `docker/main/ramsey-compose.yml` from `36003:8501` to `36003:8080`; the external host port `36003` is unchanged.

Merge/deploy alongside the new `benferenchak/ramsey-ui` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)