### PR TITLE
Fleet abstraction Phase 1a: fleet table + resolve/repoint/pause API

### DIFF
--- a/database/init-script.ddl
+++ b/database/init-script.ddl
@@ -53,6 +53,16 @@ CREATE TABLE `ramsey-dev`.`campaign` (
     PRIMARY KEY (`campaign_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
+CREATE TABLE `ramsey-dev`.`fleet` (
+    `platform` varchar(32) NOT NULL,
+    `campaign_id` int DEFAULT NULL,
+    `status` enum ('RUNNING', 'PAUSED') NOT NULL DEFAULT 'RUNNING',
+    `note` varchar(255) DEFAULT NULL,
+    `updated_date` datetime(6) DEFAULT NULL,
+    PRIMARY KEY (`platform`),
+    CONSTRAINT `fk_fleet_campaign` FOREIGN KEY (`campaign_id`) REFERENCES `ramsey-dev`.`campaign` (`campaign_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
 CREATE TABLE `ramsey-dev`.work_result (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     base_graph_id INT,
@@ -118,6 +128,16 @@ CREATE TABLE `ramsey-test`.`campaign` (
                                          `total_pairs` bigint DEFAULT NULL,
                                          PRIMARY KEY (`campaign_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `ramsey-test`.`fleet` (
+    `platform` varchar(32) NOT NULL,
+    `campaign_id` int DEFAULT NULL,
+    `status` enum ('RUNNING', 'PAUSED') NOT NULL DEFAULT 'RUNNING',
+    `note` varchar(255) DEFAULT NULL,
+    `updated_date` datetime(6) DEFAULT NULL,
+    PRIMARY KEY (`platform`),
+    CONSTRAINT `fk_fleet_campaign_test` FOREIGN KEY (`campaign_id`) REFERENCES `ramsey-test`.`campaign` (`campaign_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 
 CREATE DATABASE `ramsey` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */;

--- a/docs/investigations/fleet-abstraction-plan.md
+++ b/docs/investigations/fleet-abstraction-plan.md
@@ -63,13 +63,21 @@ Repoint = `UPDATE fleet SET campaign_id=? WHERE platform=?` (or the PUT endpoint
 ```sql
 CREATE TABLE fleet (
   platform      VARCHAR(32)  NOT NULL PRIMARY KEY,   -- 'm4-max' | 'm1' | 'vast-ai' (extensible)
-  campaign_id   INT          NULL,                   -- NULL = idle (workers poll & wait)
+  campaign_id   INT          NULL,                   -- NULL = unmapped (idle, no target)
+  status        VARCHAR(16)  NOT NULL DEFAULT 'RUNNING',  -- 'RUNNING' | 'PAUSED'
   updated_date  DATETIME(6)  NULL,
   note          VARCHAR(255) NULL,                   -- free text, e.g. 'benchmark' / 'ILS run 3'
   CONSTRAINT fk_fleet_campaign FOREIGN KEY (campaign_id) REFERENCES campaign(campaign_id)
 );
 ```
 Seed with current reality at migration time (see §7 / §13 for the values live on the day of rollout).
+
+### Fleet `status` — the pause switch (distinct from unmapping)
+Two ways to stop a fleet, for different intents:
+- **PAUSE** (`status='PAUSED'`) — stop the workers but **keep** `campaign_id`. Use for "stop burning compute for now / maintenance / hold this fleet" without forgetting what it was on. Resume returns it to exactly where it was.
+- **UNMAP** (`campaign_id=NULL`) — no target at all (retire the assignment).
+
+The resolve endpoint (§4.1) returns **204 whenever `status='PAUSED'`**, regardless of `campaign_id`, so paused workers idle-poll and resume instantly on un-pause. `RUNNING` + a mapped campaign with an ACTIVE stage is the only case that returns a stage. This gives a clean fleet-wide stop/start that the Phase-2 ILS controller also uses (e.g., pause a fleet between a wall and the next kick).
 
 ### `campaign.status` removal
 - `campaign` currently has a `status ENUM('ACTIVE','INACTIVE')`. **Drop it** — but only in the *last* migration step (§7 Phase 1d), after all code references are gone.
@@ -92,18 +100,20 @@ All under the existing `/api/ramsey` base.
 ```
 GET /api/ramsey/fleets/{platform}/active-stage
  200 → StageDto  { stageId, campaignId, baseGraphId, workEnumerationStrategy, ... }   (same shape workers get today)
- 204 → (no body)  fleet unmapped (campaign_id NULL) OR mapped campaign has no ACTIVE stage → worker idles/polls
+ 204 → (no body)  status=PAUSED, OR campaign_id NULL, OR mapped campaign has no ACTIVE stage → worker idles/polls
  404 → unknown platform
 ```
-Resolution: `fleet.platform → campaign_id → SELECT stage WHERE campaign_id=? AND status='ACTIVE' LIMIT 1`. Return the same StageDto the worker already consumes so nothing downstream changes.
+Resolution: if `status='PAUSED'` → 204. Else `fleet.platform → campaign_id → SELECT stage WHERE campaign_id=? AND status='ACTIVE' LIMIT 1`. Return the same StageDto the worker already consumes so nothing downstream changes.
 
-### 4.2 Repoint / read the mapping (ops + Phase-2 controller)
+### 4.2 Repoint / pause / read the mapping (ops + Phase-2 controller)
 ```
-GET  /api/ramsey/fleets                       → [ {platform, campaignId, updatedDate, note}, ... ]
-GET  /api/ramsey/fleets/{platform}            → {platform, campaignId, updatedDate, note}
-PUT  /api/ramsey/fleets/{platform}            body {campaignId: <int|null>, note?: <str>}  → 200 updated row
+GET  /api/ramsey/fleets                       → [ {platform, campaignId, status, updatedDate, note}, ... ]
+GET  /api/ramsey/fleets/{platform}            → {platform, campaignId, status, updatedDate, note}
+PUT  /api/ramsey/fleets/{platform}            body {campaignId?: <int|null>, status?: 'RUNNING'|'PAUSED', note?: <str>}  → 200 updated row
+POST /api/ramsey/fleets/{platform}/pause      → 200  (convenience: sets status=PAUSED, keeps campaign_id)
+POST /api/ramsey/fleets/{platform}/resume     → 200  (convenience: sets status=RUNNING)
 ```
-`PUT` upserts the mapping and sets `updated_date=now`. `campaignId=null` idles the fleet. This is the single "move a fleet" primitive used by both a human (curl) and the Phase-2 ILS controller.
+`PUT` upserts and sets `updated_date=now`; only the supplied fields change (partial update). `campaignId=null` unmaps; `status=PAUSED` holds the target but idles workers. These are the "move / pause / resume a fleet" primitives used by both a human (curl) and the Phase-2 ILS controller.
 
 ### 4.3 Bank / retire a campaign (replaces "set campaign INACTIVE")
 Banking is now two independent actions, both stage/fleet-level (no campaign.status):
@@ -209,6 +219,7 @@ The system is live and must not drop work. Each phase is independently deployabl
 1. **Fleet repointed mid-batch** — worker finishes old claimed range (valid), moves next cycle. Safe.
 2. **Two fleets on one campaign** (e.g., M4 + M1 both on campaign X) — both resolve to the same ACTIVE stage, claim from the same Redis counter → additive throughput. Explicitly supported (it's what we do manually today).
 3. **Fleet points at a campaign with no ACTIVE stage** (just deactivated) → 204 → worker idles. Resumes when repointed or a stage appears.
+3b. **Paused fleet** (`status=PAUSED`) → 204 for all its workers → they idle-poll; on resume they pick the mapped campaign's active stage back up within one cycle. Pause preserves `campaign_id` (unlike unmap).
 4. **QM manages a fleet-less campaign** — sits (claim-based exhaustion never fires without workers). Harmless; deactivate the stage to fully retire.
 5. **`processed_graph_hashes` global set** — unchanged; SHA-256 exact-graph identity, safe across concurrently-managed campaigns.
 6. **Dropping `campaign.status` breaks the UI** — mitigated by §6d; gate the column drop on the UI change.
@@ -247,8 +258,8 @@ INSERT INTO fleet (platform, campaign_id, updated_date, note) VALUES
 
 ## 14. Definition of done (Phase 1)
 
-- [ ] `fleet` table live; `GET/PUT /fleets` + `GET /fleets/{p}/active-stage` working.
-- [ ] All workers (M4, M1, Vast template) run on `RAMSEY_FLEET`; **a fleet repoint via DB/API moves them with no redeploy** (proven live, incl. the M1 without SSH).
+- [ ] `fleet` table live; `GET/PUT /fleets` + `GET /fleets/{p}/active-stage` + pause/resume working.
+- [ ] All workers (M4, M1, Vast template) run on `RAMSEY_FLEET`; **a fleet repoint via DB/API moves them with no redeploy** (proven live, incl. the M1 without SSH); **pause/resume stops and restarts a fleet with no redeploy.**
 - [ ] One campaign-agnostic QM manages all live campaigns; `ramsey-queue-manager-mseed` retired.
 - [ ] `campaign.status` gone from code and schema; UI's "active campaign" derives from active-stage/fleet.
 - [ ] Docs updated (this file → status IMPLEMENTED; README index; memory `project` note). Rotations/repoints henceforth are DB updates.

--- a/src/main/java/com/setminusx/ramsey/mw/controller/FleetController.java
+++ b/src/main/java/com/setminusx/ramsey/mw/controller/FleetController.java
@@ -1,0 +1,75 @@
+package com.setminusx.ramsey.mw.controller;
+
+import com.setminusx.ramsey.mw.dto.FleetUpdateRequest;
+import com.setminusx.ramsey.mw.entity.Fleet;
+import com.setminusx.ramsey.mw.entity.Stage;
+import com.setminusx.ramsey.mw.service.FleetService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+/**
+ * Fleet targeting API. A fleet (platform: m4-max/m1/vast-ai) maps to a campaign
+ * and has a RUNNING/PAUSED status; repointing/pausing is a DB update here, no
+ * worker redeploy. See docs/investigations/fleet-abstraction-plan.md.
+ * Internal API — no auth (mw is on the internal network).
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/ramsey/fleets")
+@lombok.RequiredArgsConstructor
+public class FleetController {
+
+    private final FleetService fleetService;
+
+    @GetMapping
+    public List<Fleet> list() {
+        return fleetService.list();
+    }
+
+    @GetMapping("/{platform}")
+    public Fleet get(@PathVariable String platform) {
+        return fleetService.get(platform)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Fleet not found: " + platform));
+    }
+
+    /**
+     * The worker's hot call. 200 + Stage when RUNNING and the mapped campaign has
+     * an ACTIVE stage; 204 when paused / unmapped / no active stage; 404 unknown platform.
+     */
+    @GetMapping("/{platform}/active-stage")
+    public ResponseEntity<Stage> activeStage(@PathVariable String platform) {
+        if (fleetService.get(platform).isEmpty()) {
+            throw new ResponseStatusException(NOT_FOUND, "Fleet not found: " + platform);
+        }
+        return fleetService.resolveActiveStage(platform)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @PutMapping("/{platform}")
+    public Fleet update(@PathVariable String platform, @RequestBody FleetUpdateRequest req) {
+        log.info("Updating fleet {}: campaignIdPresent={} campaignId={} status={} note={}",
+                platform, req.isCampaignIdPresent(), req.getCampaignId(), req.getStatus(), req.getNote());
+        return fleetService.update(platform, req);
+    }
+
+    @PostMapping("/{platform}/pause")
+    public Fleet pause(@PathVariable String platform) {
+        log.info("Pausing fleet {}", platform);
+        return fleetService.setStatus(platform, Fleet.Status.PAUSED)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Fleet not found: " + platform));
+    }
+
+    @PostMapping("/{platform}/resume")
+    public Fleet resume(@PathVariable String platform) {
+        log.info("Resuming fleet {}", platform);
+        return fleetService.setStatus(platform, Fleet.Status.RUNNING)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "Fleet not found: " + platform));
+    }
+}

--- a/src/main/java/com/setminusx/ramsey/mw/dto/FleetUpdateRequest.java
+++ b/src/main/java/com/setminusx/ramsey/mw/dto/FleetUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.setminusx.ramsey.mw.dto;
+
+import com.setminusx.ramsey.mw.entity.Fleet;
+import lombok.Data;
+
+/**
+ * Partial-update body for PUT /api/ramsey/fleets/{platform}. Only non-null fields
+ * are applied. campaignId is wrapped so that an explicit null (unmap) is
+ * distinguishable from "field omitted": use {@link #campaignIdPresent}.
+ */
+@Data
+public class FleetUpdateRequest {
+    private Integer campaignId;
+    private boolean campaignIdPresent; // set true by the setter so null-unmap is intentional
+    private Fleet.Status status;
+    private String note;
+
+    public void setCampaignId(Integer campaignId) {
+        this.campaignId = campaignId;
+        this.campaignIdPresent = true;
+    }
+}

--- a/src/main/java/com/setminusx/ramsey/mw/entity/Fleet.java
+++ b/src/main/java/com/setminusx/ramsey/mw/entity/Fleet.java
@@ -1,0 +1,47 @@
+package com.setminusx.ramsey.mw.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * A fleet is a group of workers identified by a stable platform (e.g. m4-max, m1,
+ * vast-ai). The fleet's mapping to a campaign — and its running/paused state — is
+ * the single source of truth for what those workers process. Repointing or pausing
+ * a fleet is a DB update (via {@code /api/ramsey/fleets/...}); no worker redeploy.
+ * See docs/investigations/fleet-abstraction-plan.md.
+ */
+@Data
+@Entity
+public class Fleet {
+
+    /** Platform identifier: 'm4-max' | 'm1' | 'vast-ai' (extensible). */
+    @Id
+    private String platform;
+
+    /** Target campaign; null = unmapped (workers idle, no target). */
+    private Integer campaignId;
+
+    /** RUNNING = work the mapped campaign; PAUSED = idle but keep the mapping. */
+    @Enumerated(EnumType.STRING)
+    private Fleet.Status status;
+
+    private String note;
+    private LocalDateTime updatedDate;
+
+    @PrePersist
+    @PreUpdate
+    protected void touch() {
+        updatedDate = LocalDateTime.now();
+        if (status == null) {
+            status = Status.RUNNING;
+        }
+    }
+
+    public enum Status {
+        RUNNING,
+        PAUSED
+    }
+
+}

--- a/src/main/java/com/setminusx/ramsey/mw/repository/FleetRepo.java
+++ b/src/main/java/com/setminusx/ramsey/mw/repository/FleetRepo.java
@@ -1,0 +1,9 @@
+package com.setminusx.ramsey.mw.repository;
+
+import com.setminusx.ramsey.mw.entity.Fleet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FleetRepo extends JpaRepository<Fleet, String> {
+}

--- a/src/main/java/com/setminusx/ramsey/mw/service/FleetService.java
+++ b/src/main/java/com/setminusx/ramsey/mw/service/FleetService.java
@@ -1,0 +1,72 @@
+package com.setminusx.ramsey.mw.service;
+
+import com.setminusx.ramsey.mw.dto.FleetUpdateRequest;
+import com.setminusx.ramsey.mw.entity.Fleet;
+import com.setminusx.ramsey.mw.entity.Stage;
+import com.setminusx.ramsey.mw.repository.FleetRepo;
+import com.setminusx.ramsey.mw.repository.StageRepo;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@lombok.RequiredArgsConstructor
+public class FleetService {
+
+    private final FleetRepo fleetRepo;
+    private final StageRepo stageRepo;
+
+    public List<Fleet> list() {
+        return fleetRepo.findAll();
+    }
+
+    public Optional<Fleet> get(String platform) {
+        return fleetRepo.findById(platform);
+    }
+
+    /**
+     * Resolve the stage a fleet's workers should process:
+     *  - unknown platform -> empty (caller returns 404)
+     *  - PAUSED           -> empty (caller returns 204; mapping preserved)
+     *  - unmapped         -> empty (caller returns 204)
+     *  - mapped, no ACTIVE stage -> empty (204)
+     *  - mapped + ACTIVE stage -> that stage (200)
+     * Distinguish 404 from 204 with {@link #get(String)} for existence.
+     */
+    public Optional<Stage> resolveActiveStage(String platform) {
+        Fleet fleet = fleetRepo.findById(platform).orElse(null);
+        if (fleet == null || fleet.getStatus() == Fleet.Status.PAUSED || fleet.getCampaignId() == null) {
+            return Optional.empty();
+        }
+        return stageRepo.findByCampaignIdAndStatus(fleet.getCampaignId(), Stage.Status.ACTIVE)
+                .stream().findFirst();
+    }
+
+    /** Upsert a fleet with a partial update (only supplied fields change). */
+    public Fleet update(String platform, FleetUpdateRequest req) {
+        Fleet fleet = fleetRepo.findById(platform).orElseGet(() -> {
+            Fleet f = new Fleet();
+            f.setPlatform(platform);
+            f.setStatus(Fleet.Status.RUNNING);
+            return f;
+        });
+        if (req.isCampaignIdPresent()) {
+            fleet.setCampaignId(req.getCampaignId());
+        }
+        if (req.getStatus() != null) {
+            fleet.setStatus(req.getStatus());
+        }
+        if (req.getNote() != null) {
+            fleet.setNote(req.getNote());
+        }
+        return fleetRepo.save(fleet);
+    }
+
+    public Optional<Fleet> setStatus(String platform, Fleet.Status status) {
+        return fleetRepo.findById(platform).map(fleet -> {
+            fleet.setStatus(status);
+            return fleetRepo.save(fleet);
+        });
+    }
+}

--- a/src/test/java/com/setminusx/ramsey/mw/service/FleetServiceTest.java
+++ b/src/test/java/com/setminusx/ramsey/mw/service/FleetServiceTest.java
@@ -1,0 +1,120 @@
+package com.setminusx.ramsey.mw.service;
+
+import com.setminusx.ramsey.mw.dto.FleetUpdateRequest;
+import com.setminusx.ramsey.mw.entity.Fleet;
+import com.setminusx.ramsey.mw.entity.Stage;
+import com.setminusx.ramsey.mw.repository.FleetRepo;
+import com.setminusx.ramsey.mw.repository.StageRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FleetServiceTest {
+
+    @Mock FleetRepo fleetRepo;
+    @Mock StageRepo stageRepo;
+    @InjectMocks FleetService service;
+
+    private Fleet fleet(Integer campaignId, Fleet.Status status) {
+        Fleet f = new Fleet();
+        f.setPlatform("m4-max");
+        f.setCampaignId(campaignId);
+        f.setStatus(status);
+        return f;
+    }
+
+    private Stage activeStage(int campaignId) {
+        Stage s = new Stage();
+        s.setStageId(999);
+        s.setCampaignId(campaignId);
+        s.setStatus(Stage.Status.ACTIVE);
+        return s;
+    }
+
+    @Test
+    void unknownPlatform_resolvesEmpty() {
+        when(fleetRepo.findById("nope")).thenReturn(Optional.empty());
+        assertTrue(service.resolveActiveStage("nope").isEmpty());
+        verifyNoInteractions(stageRepo);
+    }
+
+    @Test
+    void paused_resolvesEmpty_evenWhenMapped() {
+        when(fleetRepo.findById("m4-max")).thenReturn(Optional.of(fleet(3, Fleet.Status.PAUSED)));
+        assertTrue(service.resolveActiveStage("m4-max").isEmpty());
+        verifyNoInteractions(stageRepo); // must not query stages when paused
+    }
+
+    @Test
+    void unmapped_resolvesEmpty() {
+        when(fleetRepo.findById("m4-max")).thenReturn(Optional.of(fleet(null, Fleet.Status.RUNNING)));
+        assertTrue(service.resolveActiveStage("m4-max").isEmpty());
+        verifyNoInteractions(stageRepo);
+    }
+
+    @Test
+    void runningMappedWithActiveStage_resolvesThatStage() {
+        when(fleetRepo.findById("m4-max")).thenReturn(Optional.of(fleet(3, Fleet.Status.RUNNING)));
+        when(stageRepo.findByCampaignIdAndStatus(3, Stage.Status.ACTIVE))
+                .thenReturn(List.of(activeStage(3)));
+        Optional<Stage> resolved = service.resolveActiveStage("m4-max");
+        assertTrue(resolved.isPresent());
+        assertEquals(999, resolved.get().getStageId());
+    }
+
+    @Test
+    void runningMappedButNoActiveStage_resolvesEmpty() {
+        when(fleetRepo.findById("m4-max")).thenReturn(Optional.of(fleet(3, Fleet.Status.RUNNING)));
+        when(stageRepo.findByCampaignIdAndStatus(3, Stage.Status.ACTIVE)).thenReturn(List.of());
+        assertTrue(service.resolveActiveStage("m4-max").isEmpty());
+    }
+
+    @Test
+    void update_partial_onlyChangesSuppliedFields() {
+        Fleet existing = fleet(3, Fleet.Status.RUNNING);
+        existing.setNote("orig");
+        when(fleetRepo.findById("m4-max")).thenReturn(Optional.of(existing));
+        when(fleetRepo.save(any(Fleet.class))).thenAnswer(i -> i.getArgument(0));
+
+        FleetUpdateRequest req = new FleetUpdateRequest();
+        req.setStatus(Fleet.Status.PAUSED); // only status supplied; campaignId + note untouched
+
+        Fleet updated = service.update("m4-max", req);
+        assertEquals(Fleet.Status.PAUSED, updated.getStatus());
+        assertEquals(3, updated.getCampaignId());   // preserved
+        assertEquals("orig", updated.getNote());     // preserved
+    }
+
+    @Test
+    void update_explicitNullCampaignId_unmaps() {
+        Fleet existing = fleet(3, Fleet.Status.RUNNING);
+        when(fleetRepo.findById("m4-max")).thenReturn(Optional.of(existing));
+        when(fleetRepo.save(any(Fleet.class))).thenAnswer(i -> i.getArgument(0));
+
+        FleetUpdateRequest req = new FleetUpdateRequest();
+        req.setCampaignId(null); // setter marks campaignIdPresent=true → intentional unmap
+
+        Fleet updated = service.update("m4-max", req);
+        assertNull(updated.getCampaignId());
+    }
+
+    @Test
+    void update_createsFleetWhenAbsent() {
+        when(fleetRepo.findById("vast-ai")).thenReturn(Optional.empty());
+        when(fleetRepo.save(any(Fleet.class))).thenAnswer(i -> i.getArgument(0));
+        FleetUpdateRequest req = new FleetUpdateRequest();
+        req.setCampaignId(10);
+        Fleet created = service.update("vast-ai", req);
+        assertEquals("vast-ai", created.getPlatform());
+        assertEquals(10, created.getCampaignId());
+    }
+}


### PR DESCRIPTION
First slice of the fleet abstraction (spec: `docs/investigations/fleet-abstraction-plan.md`). **Additive and behavior-neutral** — workers still use `RAMSEY_CAMPAIGN_ID` until Phase 1b, so nothing changes in production on merge.

## What
A DB `fleet` table (platform → campaign + RUNNING/PAUSED status) and the middleware API to resolve, repoint, and pause fleets — the substrate that later lets any fleet be moved/paused with a DB update instead of a redeploy (and fixes the M1-can't-repoint-without-SSH problem in 1b).

- `GET  /api/ramsey/fleets` · `GET /api/ramsey/fleets/{platform}`
- `GET  /api/ramsey/fleets/{platform}/active-stage` — the worker hot call: **200** + Stage when RUNNING & mapped campaign has an ACTIVE stage; **204** when paused / unmapped / no active stage; **404** unknown platform. Returns the same `Stage` shape workers already consume.
- `PUT  /api/ramsey/fleets/{platform}` — partial update (`campaignId` / `status` / `note`); `campaignId:null` unmaps.
- `POST /api/ramsey/fleets/{platform}/pause` · `/resume` — pause keeps the mapping but idles the fleet.

## Notes
- `Fleet` entity + `fleet` table DDL added for `ramsey-dev` and `ramsey-test`. On `ddl-auto=none` (dev/prod) the table is created by the rollout migration (Phase 1a rollout step); local (`ddl-auto=update`) auto-creates from the entity.
- Partial-update semantics: `FleetUpdateRequest` marks `campaignIdPresent` so an explicit null (unmap) is distinguishable from an omitted field.
- 8 unit tests on the resolve/update logic (paused→empty & never queries stages, unmapped→empty, mapped+active→stage, partial update preserves fields, explicit-null unmaps, upsert-creates). `mvn test` green.

## Not in this PR (later phases)
1b workers on `RAMSEY_FLEET`, 1c single campaign-agnostic QM, 1d drop `campaign.status` + UI change. See the plan doc §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb3eJkqTxaiKmUU79QQYpw