### PR TITLE
Fleet abstraction Phase 1d: remove stored campaign.status (derive it)

### DIFF
--- a/database/init-script.ddl
+++ b/database/init-script.ddl
@@ -1,3 +1,11 @@
+-- Fleet abstraction (2026-07-18): the campaign.status column was removed. Campaign
+-- liveness is now DERIVED (ACTIVE iff the campaign has an ACTIVE stage; computed in
+-- CampaignService), and worker targeting comes from the fleet table, not campaign
+-- status. Migration for an EXISTING database (run once, after deploying the code
+-- that no longer maps the column):
+--     ALTER TABLE `ramsey-dev`.`campaign` DROP COLUMN `status`;
+-- See docs/investigations/fleet-abstraction-plan.md.
+
 CREATE DATABASE `ramsey-dev` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */;
 
 CREATE USER 'ramsey-user-dev'@'%' IDENTIFIED BY '<password>';
@@ -44,7 +52,6 @@ CREATE TABLE `ramsey-dev`.`stage` (
 CREATE TABLE `ramsey-dev`.`campaign` (
     `campaign_id` int NOT NULL AUTO_INCREMENT,
     `created_date` datetime(6) DEFAULT NULL,
-    `status` enum ('ACTIVE', 'INACTIVE') DEFAULT NULL,
     `strategy` enum ('COMPREHENSIVE_EDGE_PAIR_MUTATION') DEFAULT NULL,
     `subgraph_size` int DEFAULT NULL,
     `updated_date` datetime(6) DEFAULT NULL,
@@ -110,7 +117,6 @@ CREATE TABLE `ramsey-test`.`stage` (
 CREATE TABLE `ramsey-test`.`campaign` (
                                          `campaign_id` int NOT NULL AUTO_INCREMENT,
                                          `created_date` datetime(6) DEFAULT NULL,
-                                         `status` enum ('ACTIVE', 'INACTIVE') DEFAULT NULL,
                                          `strategy` enum ('COMPREHENSIVE_EDGE_PAIR_MUTATION') DEFAULT NULL,
                                          `subgraph_size` int DEFAULT NULL,
                                          `updated_date` datetime(6) DEFAULT NULL,
@@ -166,7 +172,6 @@ CREATE TABLE `ramsey`.`stage` (
 CREATE TABLE `ramsey`.`campaign` (
                                          `campaign_id` int NOT NULL AUTO_INCREMENT,
                                          `created_date` datetime(6) DEFAULT NULL,
-                                         `status` enum ('ACTIVE', 'INACTIVE') DEFAULT NULL,
                                          `strategy` enum ('COMPREHENSIVE_EDGE_PAIR_MUTATION') DEFAULT NULL,
                                          `subgraph_size` int DEFAULT NULL,
                                          `updated_date` datetime(6) DEFAULT NULL,

--- a/docs/investigations/fleet-abstraction-plan.md
+++ b/docs/investigations/fleet-abstraction-plan.md
@@ -63,13 +63,21 @@ Repoint = `UPDATE fleet SET campaign_id=? WHERE platform=?` (or the PUT endpoint
 ```sql
 CREATE TABLE fleet (
   platform      VARCHAR(32)  NOT NULL PRIMARY KEY,   -- 'm4-max' | 'm1' | 'vast-ai' (extensible)
-  campaign_id   INT          NULL,                   -- NULL = idle (workers poll & wait)
+  campaign_id   INT          NULL,                   -- NULL = unmapped (idle, no target)
+  status        VARCHAR(16)  NOT NULL DEFAULT 'RUNNING',  -- 'RUNNING' | 'PAUSED'
   updated_date  DATETIME(6)  NULL,
   note          VARCHAR(255) NULL,                   -- free text, e.g. 'benchmark' / 'ILS run 3'
   CONSTRAINT fk_fleet_campaign FOREIGN KEY (campaign_id) REFERENCES campaign(campaign_id)
 );
 ```
 Seed with current reality at migration time (see §7 / §13 for the values live on the day of rollout).
+
+### Fleet `status` — the pause switch (distinct from unmapping)
+Two ways to stop a fleet, for different intents:
+- **PAUSE** (`status='PAUSED'`) — stop the workers but **keep** `campaign_id`. Use for "stop burning compute for now / maintenance / hold this fleet" without forgetting what it was on. Resume returns it to exactly where it was.
+- **UNMAP** (`campaign_id=NULL`) — no target at all (retire the assignment).
+
+The resolve endpoint (§4.1) returns **204 whenever `status='PAUSED'`**, regardless of `campaign_id`, so paused workers idle-poll and resume instantly on un-pause. `RUNNING` + a mapped campaign with an ACTIVE stage is the only case that returns a stage. This gives a clean fleet-wide stop/start that the Phase-2 ILS controller also uses (e.g., pause a fleet between a wall and the next kick).
 
 ### `campaign.status` removal
 - `campaign` currently has a `status ENUM('ACTIVE','INACTIVE')`. **Drop it** — but only in the *last* migration step (§7 Phase 1d), after all code references are gone.
@@ -92,18 +100,20 @@ All under the existing `/api/ramsey` base.
 ```
 GET /api/ramsey/fleets/{platform}/active-stage
  200 → StageDto  { stageId, campaignId, baseGraphId, workEnumerationStrategy, ... }   (same shape workers get today)
- 204 → (no body)  fleet unmapped (campaign_id NULL) OR mapped campaign has no ACTIVE stage → worker idles/polls
+ 204 → (no body)  status=PAUSED, OR campaign_id NULL, OR mapped campaign has no ACTIVE stage → worker idles/polls
  404 → unknown platform
 ```
-Resolution: `fleet.platform → campaign_id → SELECT stage WHERE campaign_id=? AND status='ACTIVE' LIMIT 1`. Return the same StageDto the worker already consumes so nothing downstream changes.
+Resolution: if `status='PAUSED'` → 204. Else `fleet.platform → campaign_id → SELECT stage WHERE campaign_id=? AND status='ACTIVE' LIMIT 1`. Return the same StageDto the worker already consumes so nothing downstream changes.
 
-### 4.2 Repoint / read the mapping (ops + Phase-2 controller)
+### 4.2 Repoint / pause / read the mapping (ops + Phase-2 controller)
 ```
-GET  /api/ramsey/fleets                       → [ {platform, campaignId, updatedDate, note}, ... ]
-GET  /api/ramsey/fleets/{platform}            → {platform, campaignId, updatedDate, note}
-PUT  /api/ramsey/fleets/{platform}            body {campaignId: <int|null>, note?: <str>}  → 200 updated row
+GET  /api/ramsey/fleets                       → [ {platform, campaignId, status, updatedDate, note}, ... ]
+GET  /api/ramsey/fleets/{platform}            → {platform, campaignId, status, updatedDate, note}
+PUT  /api/ramsey/fleets/{platform}            body {campaignId?: <int|null>, status?: 'RUNNING'|'PAUSED', note?: <str>}  → 200 updated row
+POST /api/ramsey/fleets/{platform}/pause      → 200  (convenience: sets status=PAUSED, keeps campaign_id)
+POST /api/ramsey/fleets/{platform}/resume     → 200  (convenience: sets status=RUNNING)
 ```
-`PUT` upserts the mapping and sets `updated_date=now`. `campaignId=null` idles the fleet. This is the single "move a fleet" primitive used by both a human (curl) and the Phase-2 ILS controller.
+`PUT` upserts and sets `updated_date=now`; only the supplied fields change (partial update). `campaignId=null` unmaps; `status=PAUSED` holds the target but idles workers. These are the "move / pause / resume a fleet" primitives used by both a human (curl) and the Phase-2 ILS controller.
 
 ### 4.3 Bank / retire a campaign (replaces "set campaign INACTIVE")
 Banking is now two independent actions, both stage/fleet-level (no campaign.status):
@@ -209,6 +219,7 @@ The system is live and must not drop work. Each phase is independently deployabl
 1. **Fleet repointed mid-batch** — worker finishes old claimed range (valid), moves next cycle. Safe.
 2. **Two fleets on one campaign** (e.g., M4 + M1 both on campaign X) — both resolve to the same ACTIVE stage, claim from the same Redis counter → additive throughput. Explicitly supported (it's what we do manually today).
 3. **Fleet points at a campaign with no ACTIVE stage** (just deactivated) → 204 → worker idles. Resumes when repointed or a stage appears.
+3b. **Paused fleet** (`status=PAUSED`) → 204 for all its workers → they idle-poll; on resume they pick the mapped campaign's active stage back up within one cycle. Pause preserves `campaign_id` (unlike unmap).
 4. **QM manages a fleet-less campaign** — sits (claim-based exhaustion never fires without workers). Harmless; deactivate the stage to fully retire.
 5. **`processed_graph_hashes` global set** — unchanged; SHA-256 exact-graph identity, safe across concurrently-managed campaigns.
 6. **Dropping `campaign.status` breaks the UI** — mitigated by §6d; gate the column drop on the UI change.
@@ -247,8 +258,8 @@ INSERT INTO fleet (platform, campaign_id, updated_date, note) VALUES
 
 ## 14. Definition of done (Phase 1)
 
-- [ ] `fleet` table live; `GET/PUT /fleets` + `GET /fleets/{p}/active-stage` working.
-- [ ] All workers (M4, M1, Vast template) run on `RAMSEY_FLEET`; **a fleet repoint via DB/API moves them with no redeploy** (proven live, incl. the M1 without SSH).
+- [ ] `fleet` table live; `GET/PUT /fleets` + `GET /fleets/{p}/active-stage` + pause/resume working.
+- [ ] All workers (M4, M1, Vast template) run on `RAMSEY_FLEET`; **a fleet repoint via DB/API moves them with no redeploy** (proven live, incl. the M1 without SSH); **pause/resume stops and restarts a fleet with no redeploy.**
 - [ ] One campaign-agnostic QM manages all live campaigns; `ramsey-queue-manager-mseed` retired.
 - [ ] `campaign.status` gone from code and schema; UI's "active campaign" derives from active-stage/fleet.
 - [ ] Docs updated (this file → status IMPLEMENTED; README index; memory `project` note). Rotations/repoints henceforth are DB updates.

--- a/src/main/java/com/setminusx/ramsey/mw/entity/Campaign.java
+++ b/src/main/java/com/setminusx/ramsey/mw/entity/Campaign.java
@@ -19,7 +19,12 @@ public class Campaign {
     @Enumerated(EnumType.STRING)
     private Campaign.Strategy strategy;
 
-    @Enumerated(EnumType.STRING)
+    // DERIVED (not stored): ACTIVE iff the campaign has an ACTIVE stage. Populated
+    // by CampaignService. The stored campaign.status column was removed with the
+    // fleet abstraction — liveness now derives from stage state (targeting from the
+    // fleet mapping). Kept as a read-only reporting flag so the API/UI contract is
+    // unchanged. See docs/investigations/fleet-abstraction-plan.md.
+    @Transient
     private Campaign.Status status;
 
     private LocalDateTime createdDate;

--- a/src/main/java/com/setminusx/ramsey/mw/repository/CampaignRepo.java
+++ b/src/main/java/com/setminusx/ramsey/mw/repository/CampaignRepo.java
@@ -11,15 +11,15 @@ import java.util.List;
 @Repository
 public interface CampaignRepo extends JpaRepository<Campaign, Integer> {
 
+    // status is no longer a stored column (derived in CampaignService); filtering by
+    // status happens after derivation there.
     @Query("SELECT c FROM Campaign c WHERE " +
             "(:subgraphSize IS NULL OR c.subgraphSize = :subgraphSize) AND " +
             "(:vertexCount IS NULL OR c.vertexCount = :vertexCount) AND " +
-            "(:status IS NULL OR c.status = :status) AND " +
             "(:strategy IS NULL OR c.strategy = :strategy)")
-    List<Campaign> findBySubgraphSizeAndVertexCountAndStatusAndStrategy(
+    List<Campaign> findBySubgraphSizeAndVertexCountAndStrategy(
             @Param("subgraphSize") Integer subgraphSize,
             @Param("vertexCount") Integer vertexCount,
-            @Param("status") Campaign.Status status,
             @Param("strategy") Campaign.Strategy strategy);
 
 }

--- a/src/main/java/com/setminusx/ramsey/mw/service/CampaignService.java
+++ b/src/main/java/com/setminusx/ramsey/mw/service/CampaignService.java
@@ -1,12 +1,15 @@
 package com.setminusx.ramsey.mw.service;
 
 import com.setminusx.ramsey.mw.entity.Campaign;
+import com.setminusx.ramsey.mw.entity.Stage;
 import com.setminusx.ramsey.mw.repository.CampaignRepo;
 import com.setminusx.ramsey.mw.repository.StageRepo;
 
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @lombok.RequiredArgsConstructor
@@ -17,16 +20,45 @@ public class CampaignService {
 
     public List<Campaign> getCampaigns(Integer subgraphSize, Integer vertexCount, Campaign.Status status,
             Campaign.Strategy strategy) {
-        if (subgraphSize == null && vertexCount == null && status == null && strategy == null) {
-            return campaignRepo.findAll();
-        } else {
-            return campaignRepo.findBySubgraphSizeAndVertexCountAndStatusAndStrategy(subgraphSize, vertexCount, status,
-                    strategy);
+        List<Campaign> campaigns = (subgraphSize == null && vertexCount == null && strategy == null)
+                ? campaignRepo.findAll()
+                : campaignRepo.findBySubgraphSizeAndVertexCountAndStrategy(subgraphSize, vertexCount, strategy);
+
+        populateDerivedStatus(campaigns);
+
+        // status is derived (fleet abstraction); apply any status filter after derivation
+        // so the /campaigns?status= contract still works.
+        if (status != null) {
+            return campaigns.stream().filter(c -> status.equals(c.getStatus())).toList();
         }
+        return campaigns;
     }
 
     public Campaign getCampaignById(Integer id) {
-        return campaignRepo.findById(id).orElse(null);
+        Campaign campaign = campaignRepo.findById(id).orElse(null);
+        if (campaign != null) {
+            populateDerivedStatus(List.of(campaign));
+        }
+        return campaign;
+    }
+
+    /**
+     * Compute the (transient) status of each campaign: ACTIVE iff it has an ACTIVE
+     * stage, else INACTIVE. Replaces the removed stored campaign.status column.
+     */
+    private void populateDerivedStatus(List<Campaign> campaigns) {
+        if (campaigns.isEmpty()) {
+            return;
+        }
+        Set<Integer> activeCampaignIds = stageRepo
+                .findByCampaignIdAndStatus(null, Stage.Status.ACTIVE)
+                .stream()
+                .map(Stage::getCampaignId)
+                .collect(Collectors.toSet());
+        campaigns.forEach(c -> c.setStatus(
+                activeCampaignIds.contains(c.getCampaignId())
+                        ? Campaign.Status.ACTIVE
+                        : Campaign.Status.INACTIVE));
     }
 
     public Campaign createOrUpdateCampaign(Campaign campaign) {

--- a/src/test/java/com/setminusx/ramsey/mw/service/CampaignServiceTest.java
+++ b/src/test/java/com/setminusx/ramsey/mw/service/CampaignServiceTest.java
@@ -1,0 +1,80 @@
+package com.setminusx.ramsey.mw.service;
+
+import com.setminusx.ramsey.mw.entity.Campaign;
+import com.setminusx.ramsey.mw.entity.Stage;
+import com.setminusx.ramsey.mw.repository.CampaignRepo;
+import com.setminusx.ramsey.mw.repository.StageRepo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CampaignServiceTest {
+
+    @Mock CampaignRepo campaignRepo;
+    @Mock StageRepo stageRepo;
+    @InjectMocks CampaignService service;
+
+    private Campaign campaign(int id) {
+        Campaign c = new Campaign();
+        c.setCampaignId(id);
+        return c;
+    }
+
+    private Stage activeStageOf(int campaignId) {
+        Stage s = new Stage();
+        s.setCampaignId(campaignId);
+        s.setStatus(Stage.Status.ACTIVE);
+        return s;
+    }
+
+    @Test
+    void statusDerived_activeWhenCampaignHasActiveStage_elseInactive() {
+        when(campaignRepo.findAll()).thenReturn(List.of(campaign(10), campaign(11), campaign(12)));
+        // only campaigns 10 and 12 have an active stage
+        when(stageRepo.findByCampaignIdAndStatus(isNull(), eq(Stage.Status.ACTIVE)))
+                .thenReturn(List.of(activeStageOf(10), activeStageOf(12)));
+
+        List<Campaign> result = service.getCampaigns(null, null, null, null);
+
+        assertEquals(Campaign.Status.ACTIVE, byId(result, 10).getStatus());
+        assertEquals(Campaign.Status.INACTIVE, byId(result, 11).getStatus());
+        assertEquals(Campaign.Status.ACTIVE, byId(result, 12).getStatus());
+    }
+
+    @Test
+    void statusFilter_appliedAfterDerivation() {
+        when(campaignRepo.findAll()).thenReturn(List.of(campaign(10), campaign(11)));
+        when(stageRepo.findByCampaignIdAndStatus(isNull(), eq(Stage.Status.ACTIVE)))
+                .thenReturn(List.of(activeStageOf(10)));
+
+        List<Campaign> active = service.getCampaigns(null, null, Campaign.Status.ACTIVE, null);
+        assertEquals(1, active.size());
+        assertEquals(10, active.getFirst().getCampaignId());
+
+        List<Campaign> inactive = service.getCampaigns(null, null, Campaign.Status.INACTIVE, null);
+        assertEquals(1, inactive.size());
+        assertEquals(11, inactive.getFirst().getCampaignId());
+    }
+
+    @Test
+    void getById_derivesStatus() {
+        when(campaignRepo.findById(10)).thenReturn(Optional.of(campaign(10)));
+        when(stageRepo.findByCampaignIdAndStatus(isNull(), eq(Stage.Status.ACTIVE)))
+                .thenReturn(List.of(activeStageOf(10)));
+        assertEquals(Campaign.Status.ACTIVE, service.getCampaignById(10).getStatus());
+    }
+
+    private static Campaign byId(List<Campaign> cs, int id) {
+        return cs.stream().filter(c -> c.getCampaignId() == id).findFirst().orElseThrow();
+    }
+}


### PR DESCRIPTION
Final Phase-1 slice (spec: `docs/investigations/fleet-abstraction-plan.md`). Removes the stored `campaign.status` — the manually-flipped liveness flag that targeting used to key off.

## Key decision: derive, don't drop from the API
`campaign.status` becomes a **derived `@Transient` field** — `ACTIVE` iff the campaign has an `ACTIVE` stage — computed in `CampaignService`. This removes the *stored concept* (the column, the manual ACTIVE/INACTIVE flipping on rotations) while keeping the API's `status` field intact. **Consequence: the BFF's `ActiveStageResolver` and the entire `ramsey-ui` dashboard need no change** — the risky UI migration the plan flagged (§6d) is avoided, because "active" now reflects real stage state automatically.

## Changes
- `Campaign.status`: `@Enumerated`/stored → `@Transient` (computed).
- `CampaignRepo`: drop `status` from the filter query (`findBySubgraphSizeAndVertexCountAndStrategy`).
- `CampaignService`: derive status from the set of active-stage campaign ids; apply any `?status=` filter *after* derivation, so the contract is unchanged.
- `init-script.ddl`: drop `campaign.status` from all three DBs + a migration note (`ALTER TABLE campaign DROP COLUMN status`, run once after this code is live).
- 3 unit tests: derived ACTIVE/INACTIVE, post-derivation filter, `getById` derivation.

## Behavior notes
- "Banking a campaign" is now "deactivate its active stage" (there's no campaign-status flip); a campaign reads INACTIVE precisely when it has no active stage.
- POST/PUT campaign bodies with `status` are ignored (transient, not persisted) — reseed/rotation SQL that set `campaign.status` is superseded by the fleet flow.

## Ordering
Deploy the code first, then run the `ALTER ... DROP COLUMN` (Hibernate must stop mapping the column before it's dropped). Independent of 1b/1c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb3eJkqTxaiKmUU79QQYpw