### PR TITLE
Index the stage table, cache fleet resolution, and tune the fleet deployment

### DIFF
--- a/database/init-script.ddl
+++ b/database/init-script.ddl
@@ -46,7 +46,13 @@ CREATE TABLE `ramsey-dev`.`stage` (
     `updated_date` datetime(6) DEFAULT NULL,
     `work_enumeration_strategy` varchar(50) DEFAULT NULL,
     `details` text DEFAULT NULL,
-    PRIMARY KEY (`stage_id`)
+    PRIMARY KEY (`stage_id`),
+    -- Workers resolve their fleet's ACTIVE stage on every cycle; without this that is a full
+    -- table scan, and the table grows one row per stage advance (~4/min), so the cost climbs
+    -- forever. Measured at 64k rows: 11.8ms scan -> 0.13ms covering-index lookup.
+    KEY `idx_stage_campaign_status` (`campaign_id`, `status`),
+    -- Serves MAX(stage_id) per campaign and the campaign-ordered progression scans.
+    KEY `idx_stage_campaign_stage` (`campaign_id`, `stage_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 CREATE TABLE `ramsey-dev`.`campaign` (
@@ -121,7 +127,13 @@ CREATE TABLE `ramsey-test`.`stage` (
                                       `updated_date` datetime(6) DEFAULT NULL,
                                       `work_enumeration_strategy` varchar(50) DEFAULT NULL,
                                       `details` text DEFAULT NULL,
-                                      PRIMARY KEY (`stage_id`)
+                                      PRIMARY KEY (`stage_id`),
+                                      -- Workers resolve their fleet's ACTIVE stage on every cycle; without this that is a full
+                                      -- table scan, and the table grows one row per stage advance (~4/min), so the cost climbs
+                                      -- forever. Measured at 64k rows: 11.8ms scan -> 0.13ms covering-index lookup.
+                                      KEY `idx_stage_campaign_status` (`campaign_id`, `status`),
+                                      -- Serves MAX(stage_id) per campaign and the campaign-ordered progression scans.
+                                      KEY `idx_stage_campaign_stage` (`campaign_id`, `stage_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 CREATE TABLE `ramsey-test`.`campaign` (
@@ -186,7 +198,13 @@ CREATE TABLE `ramsey`.`stage` (
                                       `updated_date` datetime(6) DEFAULT NULL,
                                       `work_enumeration_strategy` varchar(50) DEFAULT NULL,
                                       `details` text DEFAULT NULL,
-                                      PRIMARY KEY (`stage_id`)
+                                      PRIMARY KEY (`stage_id`),
+                                      -- Workers resolve their fleet's ACTIVE stage on every cycle; without this that is a full
+                                      -- table scan, and the table grows one row per stage advance (~4/min), so the cost climbs
+                                      -- forever. Measured at 64k rows: 11.8ms scan -> 0.13ms covering-index lookup.
+                                      KEY `idx_stage_campaign_status` (`campaign_id`, `status`),
+                                      -- Serves MAX(stage_id) per campaign and the campaign-ordered progression scans.
+                                      KEY `idx_stage_campaign_stage` (`campaign_id`, `stage_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 CREATE TABLE `ramsey`.`campaign` (

--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -67,6 +67,7 @@ services:
       WORK_UNIT_ANALYSIS_TYPE: TARGETED
       WORK_ENUMERATION_STRATEGY: "DUAL_EDGE_CARDINALITY_WITH_SINGLES"  # singles census (majority color) + counter-based pair sweep
       TOP_RESULTS_COUNT: 50
+      STAGE_ADOPT_SETTLE_MS: 500      # pub/sub-armed settle window; 0 = pure polling
       EXHAUSTION_DELAY_MS: 15000
       CYCLE_PREVENTION_GRAPH_LOOKBACK_COUNT: 5000
       STAGE_PROGRESSION_FREQUENCY_MS: 1000

--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -108,13 +108,19 @@ services:
       RAMSEY_FLEET: m4-max  # fleet abstraction: target set in the DB `fleet` table (repoint via PUT /fleets/m4-max, no redeploy)
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      # STARTING/MINIMUM batch. The worker retunes it each cycle from measured throughput,
+      # STARTING/MINIMUM batch — a FLOOR, not a size. It must be low enough that the worker can
+      # size a batch to fit INSIDE a stage: during a descent stages last ~370ms and units cost
+      # ~40us, so the controller wants ~5,000 units, and a floor of 25,000 pinned batches at ~1s
+      # spanning 2.7 stages — every one abandoned partway once workers started reacting to stage
+      # advances. In the wall the controller grows to ~740k regardless, so a low floor costs
+      # nothing there.
+      # The worker retunes it each cycle from measured throughput,
       # targeting ~200ms of work per cycle (see next_fetch_size): it grows toward ~800k once the
       # hoisted path engages (~0.26us/unit, amortising the ~22ms fixed per-cycle cost of the fleet
       # active-stage call plus three Redis round trips) and falls back here while unhoisted
       # (~4us/unit — every stage's warmup, and all of a fast post-kick descent), where a small
       # batch is what keeps a worker responsive to stage changes.
-      WORK_UNIT_FETCH_COUNT: 25000
+      WORK_UNIT_FETCH_COUNT: 2000
       WORK_UNIT_PUBLISH_COUNT: 10000
       WORK_UNIT_POLL_FREQ: 1000
       PUBLISH_RESULTS: "false"

--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -67,7 +67,7 @@ services:
       WORK_UNIT_ANALYSIS_TYPE: TARGETED
       WORK_ENUMERATION_STRATEGY: "DUAL_EDGE_CARDINALITY_WITH_SINGLES"  # singles census (majority color) + counter-based pair sweep
       TOP_RESULTS_COUNT: 50
-      STAGE_ADOPT_SETTLE_MS: 500      # pub/sub-armed settle window; 0 = pure polling
+      STAGE_ADOPT_SETTLE_MS: 100      # pub/sub-armed settle window; 0 = pure polling
       EXHAUSTION_DELAY_MS: 15000
       CYCLE_PREVENTION_GRAPH_LOOKBACK_COUNT: 5000
       STAGE_PROGRESSION_FREQUENCY_MS: 1000

--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -108,7 +108,11 @@ services:
       RAMSEY_FLEET: m4-max  # fleet abstraction: target set in the DB `fleet` table (repoint via PUT /fleets/m4-max, no redeploy)
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      WORK_UNIT_FETCH_COUNT: 2500
+      # Raised from 2500 with the hoisted kernel: a unit now costs ~0.26us, so 2500 units was
+      # ~0.6ms of work behind a ~20ms fixed cycle cost (the per-cycle fleet active-stage HTTP
+      # call), leaving the fleet 97% idle on overhead. 50k units is ~13ms of work per cycle,
+      # and still bounds how long a worker can go without noticing a stage change.
+      WORK_UNIT_FETCH_COUNT: 50000
       WORK_UNIT_PUBLISH_COUNT: 10000
       WORK_UNIT_POLL_FREQ: 1000
       PUBLISH_RESULTS: "false"

--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -74,7 +74,7 @@ services:
       # Phase 2 perturbation (ILS kick): when a campaign is 500 stages past its
       # min, restart from a 30-red/30-blue kick of its incumbent-best graph.
       PERTURBATION_ENABLED: "true"
-      PERTURBATION_WALL_STAGES: 500
+      PERTURBATION_WALL_STAGES: 5000
       PERTURBATION_EDGE_PAIRS: 60          # base kick; geometric escalation doubles: 60,120,240,480,960,1920
       PERTURBATION_ESCALATION_CAP: 32      # max multiplier (x32) -> 6 steps
       PERTURBATION_CHECK_FREQUENCY_MS: 60000
@@ -104,7 +104,7 @@ services:
       RAMSEY_FLEET: m4-max  # fleet abstraction: target set in the DB `fleet` table (repoint via PUT /fleets/m4-max, no redeploy)
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      WORK_UNIT_FETCH_COUNT: 250000
+      WORK_UNIT_FETCH_COUNT: 2500
       WORK_UNIT_PUBLISH_COUNT: 10000
       WORK_UNIT_POLL_FREQ: 1000
       PUBLISH_RESULTS: "false"

--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -112,7 +112,7 @@ services:
       # ~0.6ms of work behind a ~20ms fixed cycle cost (the per-cycle fleet active-stage HTTP
       # call), leaving the fleet 97% idle on overhead. 50k units is ~13ms of work per cycle,
       # and still bounds how long a worker can go without noticing a stage change.
-      WORK_UNIT_FETCH_COUNT: 50000
+      WORK_UNIT_FETCH_COUNT: 250000
       WORK_UNIT_PUBLISH_COUNT: 10000
       WORK_UNIT_POLL_FREQ: 1000
       PUBLISH_RESULTS: "false"

--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -124,6 +124,9 @@ services:
       WORK_UNIT_PUBLISH_COUNT: 10000
       WORK_UNIT_POLL_FREQ: 1000
       PUBLISH_RESULTS: "false"
+      # Kill switch for the hoisted pair-move evaluation. The hoisted and seeded paths compute
+      # identical values, so this only ever trades cost — set false to fall back to the kernel.
+      HOIST_ENABLED: "true"
       TOP_RESULTS_COUNT: 50
       WORKER_COUNT: 1
     depends_on:

--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -75,7 +75,8 @@ services:
       # min, restart from a 30-red/30-blue kick of its incumbent-best graph.
       PERTURBATION_ENABLED: "true"
       PERTURBATION_WALL_STAGES: 500
-      PERTURBATION_EDGE_PAIRS: 30
+      PERTURBATION_EDGE_PAIRS: 60          # base kick; geometric escalation doubles: 60,120,240,480,960,1920
+      PERTURBATION_ESCALATION_CAP: 32      # max multiplier (x32) -> 6 steps
       PERTURBATION_CHECK_FREQUENCY_MS: 60000
       LOGGING_LEVEL_ROOT: INFO
     depends_on:

--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -108,11 +108,13 @@ services:
       RAMSEY_FLEET: m4-max  # fleet abstraction: target set in the DB `fleet` table (repoint via PUT /fleets/m4-max, no redeploy)
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      # Raised from 2500 with the hoisted kernel: a unit now costs ~0.26us, so 2500 units was
-      # ~0.6ms of work behind a ~20ms fixed cycle cost (the per-cycle fleet active-stage HTTP
-      # call), leaving the fleet 97% idle on overhead. 50k units is ~13ms of work per cycle,
-      # and still bounds how long a worker can go without noticing a stage change.
-      WORK_UNIT_FETCH_COUNT: 250000
+      # STARTING/MINIMUM batch. The worker retunes it each cycle from measured throughput,
+      # targeting ~200ms of work per cycle (see next_fetch_size): it grows toward ~800k once the
+      # hoisted path engages (~0.26us/unit, amortising the ~22ms fixed per-cycle cost of the fleet
+      # active-stage call plus three Redis round trips) and falls back here while unhoisted
+      # (~4us/unit — every stage's warmup, and all of a fast post-kick descent), where a small
+      # batch is what keeps a worker responsive to stage changes.
+      WORK_UNIT_FETCH_COUNT: 25000
       WORK_UNIT_PUBLISH_COUNT: 10000
       WORK_UNIT_POLL_FREQ: 1000
       PUBLISH_RESULTS: "false"

--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -72,10 +72,13 @@ services:
       CYCLE_PREVENTION_GRAPH_LOOKBACK_COUNT: 5000
       STAGE_PROGRESSION_FREQUENCY_MS: 1000
       IMMEDIATELY_PROGRESS_STAGE_ON_IMPROVEMENT: "true"
-      # Phase 2 perturbation (ILS kick): when a campaign is 500 stages past its
-      # min, restart from a 30-red/30-blue kick of its incumbent-best graph.
+      # Phase 2 perturbation (ILS kick): when the current basin has gone this many
+      # stages without beating its OWN floor, restart from a kick of the campaign's
+      # incumbent-best graph. The clock runs from the basin floor, not from the kick,
+      # so a descent still finding new minima is never cut off (the old fixed
+      # stages-since-kick wall killed kicks 18/19/20 mid-free-fall).
       PERTURBATION_ENABLED: "true"
-      PERTURBATION_WALL_STAGES: 5000
+      PERTURBATION_BASIN_STALE_STAGES: 100
       PERTURBATION_EDGE_PAIRS: 60          # base kick; geometric escalation doubles: 60,120,240,480,960,1920
       PERTURBATION_ESCALATION_CAP: 32      # max multiplier (x32) -> 6 steps
       PERTURBATION_CHECK_FREQUENCY_MS: 60000

--- a/docs/investigations/pair-move-hoist-proposal.md
+++ b/docs/investigations/pair-move-hoist-proposal.md
@@ -1,0 +1,339 @@
+# Proposal: hoist per-edge clique counts out of the pair-move inner loop
+
+**Status:** proposal, not implemented. Seeking review before building.
+**Date:** 2026-07-25
+**Expected gain:** ~5–15× worker throughput in the regime the search currently lives in.
+**Risk profile:** the change is *exact* (bit-identical results), so the risk is implementation bugs, not lost search quality.
+
+This document is self-contained: it defines the problem, the current algorithm, the proposed
+change with a correctness proof, the measured numbers behind the estimates, and what has already
+been ruled out. No other context is required to review it.
+
+---
+
+## 1. What the system does
+
+We are searching for a 2-coloring of the edges of the complete graph on 282 vertices (K₂₈₂) that
+contains **no monochromatic K₈** (no 8 vertices whose 28 connecting edges are all the same color).
+Finding one would prove the Ramsey bound **R(8,8) ≥ 283**, which has stood unbeaten for decades.
+
+- **n = 282** vertices, **C(282,2) = 39,621** edges, each colored RED or BLUE.
+- **k = 8**.
+- **Objective** `f(G)` = number of monochromatic 8-cliques (red ones + blue ones). We minimize it.
+  `f(G) = 0` would be the witness. Current best ever found: **25,758**. Current working graph:
+  ~25,892.
+- The coloring is kept **balanced** (equal red/blue counts): currently 19,811 red, 19,810 blue.
+
+### Search structure
+
+The search is a distributed local search. State advances in **stages**:
+
+1. A stage has a fixed **base graph** `G` with known count `f(G)` (call it `base_total`).
+2. A fleet of ~15 worker processes evaluates candidate **moves** from `G`. Each move is one
+   **work unit**.
+3. When a move improving on `base_total` is found (or the space is exhausted), the queue manager
+   promotes the best result to be the next stage's base graph. Stages advance one move at a time.
+
+### The move space (one stage)
+
+Two move classes, enumerated as one indexed space so workers can claim disjoint index ranges:
+
+| move class | definition | count |
+|---|---|---|
+| **singles** | flip one edge (either color) | 39,621 |
+| **pairs** | flip one RED edge **and** one BLUE edge (balance-preserving) | 19,811 × 19,810 ≈ 392,455,910 |
+| | **total work units per stage** | **≈ 392,495,531** |
+
+Pairs dominate the space by 4 orders of magnitude, so this proposal is about pairs.
+
+### What a worker computes per work unit
+
+For a move that flips edge set `F`, the derived graph's count is computed **incrementally**:
+
+```
+count(G_derived) = base_total − destroyed + created
+```
+
+- **`destroyed`** = number of mono cliques of `G` that contain an edge of `F`. Read from a
+  precomputed per-edge table (`edge_counts[e]` = how many mono cliques contain edge `e`), so this
+  is a couple of array lookups. **Cheap.**
+- **`created`** = number of mono cliques of the *derived* graph that contain an edge of `F`. This
+  requires actual enumeration: a **seeded Bron–Kerbosch traversal** rooted at the flipped edge's
+  endpoints. Only cliques through a flipped edge can be new, so the traversal is local, but it is
+  still ~99% of all worker CPU time.
+
+**Early abort.** Workers know the current best-known result for the stage (a "threshold"). If the
+running `created` count rises high enough that the move cannot beat the threshold, the traversal
+aborts and the unit is discarded. Concretely the abort limit is
+`limit = threshold − 1 − base_total + destroyed`.
+
+### The key measured asymmetry
+
+For a *typical* pair move at the current clique level:
+
+| quantity | value | how obtained |
+|---|---|---|
+| cliques **destroyed** per edge | **~18** | exact: 25,892 cliques × 28 pairs ÷ 39,621 edges |
+| cliques **created** by a random pair flip | **~817** | measured (19,810 sampled flips on the live graph) |
+
+Creating ~817 while destroying ~18 means **almost every pair move is far worse than the base
+graph**, so almost every unit hits the abort limit quickly and is discarded. This is why
+throughput is high per unit but the space is enormous.
+
+### Where the time goes (measured)
+
+- Fleet throughput: **~1.04M units/sec** (14 workers on one M4 Max, each ~93% CPU = saturated).
+- Per-unit average: **~13.5 µs** (derived: 1.04M/s ÷ 14 workers).
+- **One full stage sweep = 392M units ≈ 6.3 minutes.**
+- When the search is "walled" (no improving move exists), it sweeps the whole space, advances to a
+  least-bad move, and sweeps again. A 500-stage wall ≈ **52 hours** of sweeping.
+
+That 6.3 min/stage is the dominant cost of the entire project.
+
+---
+
+## 2. The proposed change
+
+### Intuition
+
+Pairs are enumerated as (red edge `r`) × (blue edge `b`). Today, for every one of the ~392M
+combinations, we run a fresh traversal. But the work splits into a part that depends only on `b`
+and a part that depends only on `r` — **plus a correction that is almost always zero**. Precompute
+the two per-edge parts once per stage (39,621 traversals), then most of the 392M units become a
+few bit tests and two array lookups.
+
+### Notation
+
+- `R` = set of red edges, `B` = set of blue edges.
+- Move: pick `r ∈ R`, `b ∈ B`; flip both. So `r` becomes blue and `b` becomes red.
+- Derived graph: `R' = (R \ {r}) ∪ {b}` and `B' = (B \ {b}) ∪ {r}`.
+- `created` = (# red k-cliques through `b` in `R'`) + (# blue k-cliques through `r` in `B'`).
+  (No other clique can be new: a new clique must use a newly-colored edge.)
+
+### Precompute (once per stage, on the base graph)
+
+```
+for every blue edge b:  C_b = # red  k-cliques through b in  R ∪ {b}     # pretend b is red
+for every red  edge r:  D_r = # blue k-cliques through r in  B ∪ {r}     # pretend r is blue
+```
+
+That is 39,621 seeded traversals — the same primitive already used per unit today.
+
+### The identity
+
+Because `R' = (R ∪ {b}) \ {r}`:
+
+```
+# red k-cliques through b in R'  =  C_b − X ,
+   where X = # red k-cliques through b in R ∪ {b} that ALSO contain edge r
+```
+
+and symmetrically, because `B' = (B ∪ {r}) \ {b}`:
+
+```
+# blue k-cliques through r in B' =  D_r − Y ,
+   where Y = # blue k-cliques through r in B ∪ {r} that ALSO contain edge b
+```
+
+So:
+
+```
+created = (C_b − X) + (D_r − Y)
+```
+
+### When are X and Y zero? (the cheap test)
+
+`X > 0` requires a single clique containing **both** edges `r` and `b`, all of whose internal pairs
+are red (in `R ∪ {b}`). Let `r = (x,y)` and `b = (u,v)`.
+
+- **Disjoint case** (`x,y,u,v` all distinct — the overwhelming majority): such a clique must contain
+  all four vertices, so all 6 internal pairs must be red. Two are given (`xy = r` is red, `uv = b` is
+  red by construction). The other four are the **cross pairs** `xu, xv, yu, yv`. Therefore:
+  **if any cross pair is BLUE, then X = 0.**
+- **Shared-vertex case** (e.g. `y = u`, so 3 distinct vertices): the clique must contain `{x, y, v}`;
+  pairs `xy = r` and `yv = b` are red, leaving **one** cross pair `xv`. **If `xv` is BLUE, X = 0.**
+- `r` and `b` cannot be the same edge (different colors).
+
+By the identical argument in the complement, `Y = 0` unless **all** cross pairs are BLUE.
+
+**Consequence:** since every cross pair is either red or blue, and there is always ≥1 cross pair,
+`X` and `Y` can never both be non-zero. Either the cross pairs are all red (only `X` can be
+non-zero), all blue (only `Y` can), or mixed (**both are zero**).
+
+### The fast path
+
+```
+FAST PATH (cross pairs mixed):        created = C_b + D_r          exactly, no traversal
+SLOW PATH (cross pairs all one color): fall back to today's seeded traversal
+```
+
+Cost on the fast path: ≤4 adjacency bit tests + 2 array lookups + a compare. Call it ~50 ns versus
+~13.5 µs today.
+
+### Estimated fast-path frequency
+
+Red/blue density is ~50% by construction (balanced coloring). For a disjoint pair with 4 cross
+pairs, assuming rough independence:
+
+```
+P(all 4 red)  ≈ (1/2)^4 = 6.25%      -> slow path (X may be non-zero)
+P(all 4 blue) ≈ (1/2)^4 = 6.25%      -> slow path (Y may be non-zero)
+P(mixed)      ≈ 87.5%                -> FAST PATH
+```
+Shared-vertex pairs (≈2.8% of pairs, only 1 cross pair) are always slow path. Net fast path
+**≈ 85%**. **This is an estimate, not a measurement** — see §5, question 2. It assumes cross-pair
+colors are roughly independent, which may not hold in a heavily optimized graph.
+
+### Estimated speedup
+
+```
+today:    13.5 µs/unit
+proposed: 0.85 × 0.05 µs + 0.15 × 13.5 µs ≈ 2.07 µs/unit   ->  ~6.5×
+```
+Upper end (~15×) requires also making the slow path cheaper — instead of a full re-traversal,
+compute `X` (or `Y`) directly by seeding from the 3–4 shared vertices, which enumerates only the
+cliques containing *both* edges (a far smaller set).
+
+### Precompute cost (small, and cappable)
+
+Each precomputed value can be **capped**: we only need the exact value when it is below the abort
+limit; anything larger just means "reject". Since a typical `C_b` is ~817 and limits are ~20–40,
+capping each traversal at e.g. 1024 makes the precompute cheap, and the common case aborts after a
+few dozen cliques.
+
+- Uncapped cost measured at ~124–190 µs per seeded traversal → 39,621 × ~190 µs ≈ **7.5 s/stage**
+  (2% of a 377 s sweep) as a pessimistic bound.
+- With capping, expected to be **well under 1 s/stage**.
+- The tables are small: 39,621 × 4 bytes ≈ **158 KB**, so they can be shared between workers over
+  Redis exactly as the existing per-edge count table already is (318 KB blob, 5-minute TTL).
+- **Incremental option:** consecutive stages differ by exactly one edge flip (verified in
+  production). The existing per-edge count table is already updated incrementally for this reason
+  (measured 1,146× cheaper than rebuilding: 378 µs vs 434 ms). The same locality argument applies
+  to `C_b`/`D_r`, so most entries carry over untouched.
+
+### Pseudocode for the inner loop
+
+```rust
+// once per stage
+let c_blue: Vec<u32> = precompute_C_for_each_blue_edge(base_graph, k, CAP);
+let d_red:  Vec<u32> = precompute_D_for_each_red_edge (base_graph, k, CAP);
+
+// per work unit (r, b)
+let (x, y) = endpoints(r);
+let (u, v) = endpoints(b);
+
+let cross_all_red  = red(x,u) && red(x,v) && red(y,u) && red(y,v);   // shared-vertex: 1 test
+let cross_all_blue = !red(x,u) && !red(x,v) && !red(y,u) && !red(y,v);
+
+let created = if !cross_all_red && !cross_all_blue {
+    c_blue[b] + d_red[r]                 // FAST PATH: exact, no traversal
+} else {
+    seeded_traversal_as_today(r, b)      // SLOW PATH: ~15% of units
+};
+
+let count = base_total - destroyed(r, b) + created;   // destroyed = cached lookups
+```
+
+---
+
+## 3. Why this is safe
+
+The change is an **algebraic identity**, not an approximation or a heuristic prune. It computes the
+same `created` value the current code computes, so every work result, every threshold decision, and
+every stage transition is **bit-identical**. It cannot cause the search to miss an improving move.
+
+This distinguishes it from a rejected alternative (see §4) that was 12× faster but provably skipped
+real improvements.
+
+### Failure modes to guard
+
+1. **Shared-vertex case handled as if disjoint.** Testing 4 cross pairs when only 1 exists (or
+   indexing a non-existent vertex pair) would silently corrupt counts. Needs explicit tests.
+2. **Cap truncation.** If a capped `C_b` is used as an exact value when the true value was needed
+   (i.e. below the limit), counts are wrong. Cap must be provably above any usable limit, or the
+   code must treat "capped" as a distinct "reject" state rather than a number.
+3. **Stale precompute.** `C_b`/`D_r` are properties of the base graph; if a stage advances and the
+   tables are not rebuilt/updated, every unit is wrong. (There is precedent: a cache in this code
+   was being wiped on every stage advance, silently defeating cross-stage reuse for a long time.)
+4. **Density assumption wrong** → fast-path fraction far below 85% → little gain. This is a
+   performance risk, not a correctness risk, and is cheap to measure first (§5).
+
+### Validation plan (mirrors what the codebase already does)
+
+- **Unit tests** on small graphs (n≈10, k=4/5) asserting `created` from the hoisted path equals a
+  brute-force recount, over both colors, disjoint and shared-vertex cases, and capped/uncapped.
+- **Production-scale equivalence harness**: for a real 282-vertex base graph, iterate a large
+  random sample of `(r,b)` pairs and assert hoisted `created` == today's `created`, exactly.
+- **Full-stage replay**: the repo has a harness that replays an entire real stage and requires
+  byte-identical output (same results, same hashes). Any kernel change must pass it. This is the
+  gate that has validated previous kernel work.
+- **Offline prototype before production code:** measure the true fast-path fraction and the real
+  per-unit costs on the live graph, and only proceed if it clears a threshold (say ≥3×).
+
+---
+
+## 4. What has already been ruled out (measured — please don't re-propose)
+
+Two similar-sounding ideas were tested and killed this week. Reviewers should know why.
+
+| idea | result | why it failed |
+|---|---|---|
+| **Dirty-edge pruning** ("only re-check moves near the last flip") | **12× faster but UNSOUND** | Sound only if the previous stage swept the *whole* space. In practice stages stop as soon as they find an improvement, so ~95% of the space was never examined and cannot be assumed non-improving. Replayed against 38 real consecutive stage transitions: the move the search actually adopted lay inside the "dirty" set only **57.9%** of the time (**51.7%** for improving moves). It would silently skip ~half the search's progress. |
+| **Red-edge sharing** (hoist only the `r`-dependent half) | superseded | The first benchmark said "1.00× ceiling", but **that benchmark was buggy** — it used a traversal primitive with no early abort, so its abort simulation never aborted. The corrected analysis is what produced *this* proposal: both halves can be hoisted, not just one, and the validity condition is the cheap cross-pair test. |
+| **Bound-skip** (skip units whose cached bound already excludes them) | implemented, **no measurable gain** (1,036,833 vs 1,041,750 u/s) | Near the floor the threshold sits at/above `base_total`, making the skip condition unreachable. Kept because it is correct and free. |
+| Faster QM polling / worker polling / longer settle windows | all measured, now ≤0.1% of a stage | Stage *overhead* was already reduced ~10× by other work (see §6); the remaining cost is the sweep itself. |
+
+Other things already done, so they are not the answer here: the per-edge count table is built
+counts-only and updated incrementally (1,146×), it is shared between workers over Redis, and stage
+adoption is driven by a pub/sub-armed settle timer rather than blind polling.
+
+---
+
+## 5. Questions for reviewers
+
+1. **Is the identity correct?** Specifically `created = (C_b − X) + (D_r − Y)` and the claim that
+   `X > 0` requires all cross pairs red (and `Y > 0` requires all cross pairs blue), including the
+   shared-vertex case and the fact that `X`, `Y` cannot both be non-zero. Any counterexample?
+2. **Is the ~85% fast-path estimate plausible?** It assumes cross-pair colors are roughly
+   independent at ~50% density. But this graph is *heavily optimized* to avoid mono cliques, and
+   pairs are enumerated in order of clique participation (highest first), which may correlate
+   cross-pair colors and depress the fast-path fraction — possibly badly, in the earliest and most
+   important part of the sweep. How would you measure this cheaply and honestly?
+3. **Precompute strategy:** rebuild `C_b`/`D_r` per stage (capped, ~1 s) and share via Redis, or
+   update incrementally from the previous stage (one flip apart) reusing existing delta machinery?
+   The incremental path is faster but adds a second consistency invariant to get wrong.
+4. **Slow path:** is it worth computing `X`/`Y` directly (seed from the 3–4 shared vertices,
+   enumerating only cliques containing both edges) instead of falling back to a full seeded
+   traversal? That is what would take this from ~6× to ~15×.
+5. **Is there something better we are missing?** The fundamental situation: ~392M candidate moves
+   per stage, of which essentially all are rejected because a random flip creates ~45× more cliques
+   than it destroys, and the search advances one move at a time. Given that, is per-unit
+   optimization even the right frame, or should the *move space itself* be reconsidered (sampling,
+   a different neighborhood, or a different acceptance rule)? Note that changing the space changes
+   search semantics, not just speed, so it is a strategy decision rather than an optimization.
+
+---
+
+## 6. Context: recent measured work (so reviewers can calibrate)
+
+For scale, the same codebase recently had these changes measured and shipped:
+
+- **Counts-only build**: stop materializing the clique list and edge→clique index that the hot path
+  never reads (~300 MB of allocation per stage per worker removed). 1.29× on the build itself.
+- **Incremental count update**: derive the per-edge table from the previous stage's (one flip apart)
+  instead of rebuilding — **378 µs vs 434 ms = 1,146×**, bit-identical (total and all 79,524 entries).
+  This removed a ~430 ms serialized head from every stage.
+- **Redis sharing + builder election** so 15 workers don't each rebuild the same table.
+- **Pub/sub-armed settle timer** replacing blind polling for stage adoption; swept the window and
+  measured 100 ms best (332 stages/min, 150k cliques/min) vs 500 ms (120 stages/min, 43k
+  cliques/min).
+
+Net effect on a post-perturbation descent: stage gaps fell from ~1.00 s to ~0.18 s, and the working
+graph descended from 2.67M mono-cliques to ~25.9k. The remaining cost is the near-floor sweep this
+proposal targets.
+
+**A caution for reviewers, learned the hard way twice this week:** two confident estimates in this
+area (a "2× kernel win" and a "20× pruning win") both collapsed when measured — one because the
+benchmark silently didn't abort, one because its soundness precondition didn't hold in production.
+Please treat the numbers in §2 marked *estimate* with suspicion, and prefer a measured prototype
+over an argued one.

--- a/docs/investigations/pair-move-hoist-review.md
+++ b/docs/investigations/pair-move-hoist-review.md
@@ -1,0 +1,193 @@
+# Review: pair-move hoist proposal — measured verdict
+
+**Reviews:** `pair-move-hoist-proposal.md` (2026-07-25)
+**Date:** 2026-07-25
+**Harness:** `single-flip-check/src/bin/pair_hoist_check.rs` (modes: `verify`, `fastpath`, `bench`,
+`profile`, `integrate`, `precompute`). It calls the shipped worker kernel
+(`get_new_cliques_with_limit`) and the shipped `CliqueCollection` / enumerators, so "production"
+in every table below is the real thing, not a re-implementation.
+
+## Verdict
+
+**Build it — the approach is sound and worth substantially more than proposed.** Measured
+**~29× on a full stage sweep** (single core), versus the proposal's 6.5×–15× estimate.
+
+Three corrections, one of them a real bug:
+
+1. The §2 pseudocode is **wrong for shared-vertex pairs** and silently corrupts 1.4% of the space.
+2. The direct-X/Y slow path is not an "upper end" nice-to-have — it is **where essentially all of
+   the win lives**, and it is *simpler* than the fallback it replaces.
+3. Capping the precompute saves nothing and is unsafe. Don't cap.
+
+---
+
+## 1. The identity is correct
+
+`created = (C_b − X) + (D_r − Y)`, with `X>0 ⟹ cross pairs all red`, `Y>0 ⟹ all blue`, and X,Y
+never both non-zero. Checked against the production kernel, uncapped, exact equality:
+
+| graph | mono-8 cliques | pairs sampled | `created` mismatches | X/Y vs brute force | both X,Y > 0 | MIXED with X or Y > 0 |
+|---|---|---|---|---|---|---|
+| 26994 (all-time best) | 25,758 | 64,000 | **0** | **0** | **0** | **0** |
+| 8644 | 25,840 | 20,000 | **0** | **0** | **0** | **0** |
+
+X and Y were also computed a second, independent way (enumerate all cliques through the edge, then
+filter for containment) and agreed everywhere. Answer to §5 Q1: **no counterexample; the algebra
+holds.**
+
+## 2. BUG — the §2 pseudocode mishandles shared-vertex pairs
+
+```rust
+let cross_all_red  = red(x,u) && red(x,v) && red(y,u) && red(y,v);   // "shared-vertex: 1 test"
+let cross_all_blue = !red(x,u) && !red(x,v) && !red(y,u) && !red(y,v);
+```
+
+The annotation is wrong: the 4-test form does **not** degenerate to the single needed test. With
+`y == u`:
+
+- `red(y,u)` = `red(y,y)` = self-loop = **false** → `cross_all_red` is always false.
+- `red(x,u)` = `red(x,y)` = `r`, which is red = true → `!red(x,u)` = false → `cross_all_blue` is
+  always false.
+
+Both false ⇒ classified **MIXED** ⇒ fast path taken with X,Y assumed zero. Measured on graph 26994:
+**63 of 63** sampled shared-vertex pairs produced a wrong `created`, errors up to **+182 cliques**.
+This is exactly failure mode §3.1, present in the proposal's own pseudocode.
+
+**Fix:** cross pairs are the internal pairs of the forced vertex set that are neither `r` nor `b`.
+Excluding the degenerate pair *and* the two that collapse onto `r`/`b` leaves exactly one cross pair
+in the shared case, and all four when disjoint. With that fix the identity is exact (table above).
+
+Shared-vertex pairs are **1.42%** of the space (the proposal says 2.8% — 2× high, immaterial), and
+they are always slow-path, never fast.
+
+## 3. Fast-path fraction: 86.32%, and flat (answers §5 Q2)
+
+Computed **exactly** over all 392,455,908 pairs (765 ms), not sampled:
+
+| class | count | share |
+|---|---|---|
+| FAST (cross pairs mixed) | 338,759,397 | **86.318%** |
+| slow — cross all RED | 24,072,506 | 6.134% |
+| slow — cross all BLUE | 24,057,327 | 6.130% |
+| slow — shared vertex | 5,566,678 | 1.418% |
+
+The §5 Q2 worry — that cardinality-descending enumeration correlates cross-pair colors and depresses
+the fast path early — **is unfounded**: 85.20% over the first 100K units, 86.48% over the first 1M,
+86.32% overall. A 1.1pp dip at the very head, nothing more.
+
+It is also not basin-specific: the live mid-descent graph 53980 (394,915 cliques) gives **86.326%**,
+essentially identical. The fraction is a structural consequence of the ~50% color density.
+
+## 4. Where the win actually is
+
+Cost is **extremely front-loaded** — production per-unit varies **38×** across a sweep, because the
+cardinality-descending enumeration puts the expensive edges first. Hoisted cost is flat.
+
+| position in pair sweep | production µs/unit | hoisted µs/unit | speedup |
+|---|---|---|---|
+| head (first units) | 158.7 | 0.353 | **450×** |
+| 1% in | 19.9 | 0.262 | 76× |
+| 10% in | 9.3 | 0.258 | 36× |
+| 30%–99% (the tail) | ~4.2 | ~0.25 | ~17× |
+| **integrated over the whole sweep** | **7.79** | **0.255** | **29×** |
+
+Two independent integrations agree: 100 uniform windows → 8.075 µs / 29.1×; 24 geometrically-spaced
+points, trapezoid → 7.791 µs / 28.9×.
+
+**A single-window benchmark would have been badly misleading here** — three different windows gave
+6.8×, 17.0×, and 362.9×. This is the same trap that produced the two collapsed estimates in §6.
+
+### The direct-X/Y slow path is the whole story
+
+| slow-path strategy | speedup (whole sweep) |
+|---|---|
+| fall back to today's seeded re-traversal (§2 main proposal) | **~7×** — matches the 6.5× estimate |
+| compute X/Y directly (§2 "upper end", estimated 15×) | **~29×** |
+
+The retraversal variant is Amdahl-capped: the 13.7% slow path is exactly the *expensive* 13.7%, so
+it dominates. Computing X/Y directly costs ~1 µs instead of ~100 µs, and there is a simplification
+the proposal misses:
+
+> **No graph mutation is needed.** X counts red k-cliques containing both `r` and `b` in `R ∪ {b}`.
+> Seed on the union vertex set S (3 or 4 vertices), take `P = ⋂_{w∈S} adj[w] \ S`, and count
+> (k−|S|)-cliques in P. The pretended edge `b` has *both* endpoints in S, which are cleared out of
+> P, so every edge induced on P is an original edge — the base adjacency is used unchanged. Same
+> argument for Y in the complement.
+
+So the "slow" path is: 4 row-ANDs, a couple of bit-clears, and a small count. No `flip_edges`, no
+kernel call, no unflip. **It is simpler than the fallback it replaces**, which inverts the §2
+recommendation to ship the simple version first.
+
+Correctness was checked continuously, not just at the end: accepted-result sets and threshold
+trajectories were identical between production and both hoisted variants at every sample point and
+across 2M+ contiguous units.
+
+## 5. Don't cap the precompute (answers §5 Q3)
+
+| | time | per edge |
+|---|---|---|
+| capped at 1024 | 5.837 s | 147.3 µs |
+| uncapped | 5.840 s | 147.4 µs |
+
+**Capping saves 0.05%.** The cost is neighbourhood exploration, not clique counting, so the abort
+never fires early enough to matter. And capping is *unsafe*: 1,171 edges exceed a 1024 cap
+(max `C_b` = 2,386), while the abort limit `threshold − 1 − base_total + destroyed` can reach ~2,970
+given a max per-edge destroyed count of 1,481. A capped entry used as an exact value under-reports
+`created` → false accept.
+
+Uncapped costs the same and **deletes failure mode §3.2 entirely**. Recommendation: rebuild
+uncapped per stage, share via Redis exactly like the existing 318 KB per-edge table (these are
+2 × 39,621 × 4 B = 317 KB). No incremental-update machinery needed — see below for why.
+
+Distribution on graph 26994: `C_b` mean 818.7 / median 784 / max 2,386; `D_r` mean 818.1 / median
+784 / max 2,299. (The proposal's ~817 figure is confirmed, and is per *single* flip, so a typical
+pair creates ~1,637.)
+
+## 6. Fleet-level caveat the proposal misses
+
+Once the sweep costs 0.255 µs/unit, it takes ~7 s across 14 workers — at which point a **5.8 s
+serialized precompute is no longer negligible**. It roughly halves the win:
+
+| build strategy | precompute | sweep (14 workers) | total | fleet speedup |
+|---|---|---|---|---|
+| today | — | 218 s | 218 s | 1× |
+| single elected builder (today's edge-counts pattern) | 5.8 s | 7.1 s | 12.9 s | **~17×** |
+| sharded across the fleet | 0.4 s | 7.1 s | 7.5 s | **~29×** |
+
+The precompute is 39,621 *independent* seeded traversals — embarrassingly parallel. **Shard it**;
+the difference between 17× and 29× is worth the extra coordination.
+
+Why no incremental update is needed: the target regime is the near-floor wall, where a stage sweeps
+the whole space (minutes). A 5.8 s (or 0.4 s sharded) rebuild is ~1% overhead there. In the fast
+descent regime — where stages advance every ~0.18 s and an incremental path would matter — the
+bound-skip already fires on nearly every unit (threshold sits far below `base_total`), so the sweep
+is already cheap and the hoist is not needed. The two regimes do not overlap.
+
+**Bonus:** the singles block becomes free as well. `created` for a single flip *is* the precomputed
+table entry, so the first 39,621 units of every stage collapse to a lookup.
+
+## 7. Measurement caveats
+
+- Run with `nice -n 15` alongside the live 14-worker fleet on a 16-core M4 Max, so **absolute** µs
+  are inflated by contention. Both loops were measured under identical conditions in the same
+  process, so the **ratios** are fair. Sweep-wide production per-unit measured 7.79 µs against the
+  proposal's stated 13.5 µs — same ballpark.
+- Benchmarked against a realistic near-floor threshold: swept the singles block first, which set
+  `threshold = base_total + 11`, exactly as a live stage does. The bound-skip never fired
+  (`skipped=0`), matching §4's note that it is unreachable near the floor.
+- The hoisted loop still allocates the per-unit `Vec<WorkUnitEdge>` that production allocates, so
+  the measured speedup is if anything **conservative**.
+
+## 8. Recommendations
+
+1. **Fix the cross-pair test** before anything else, and unit-test the shared-vertex case
+   specifically — it is 1.4% of the space and fails silently.
+2. **Make the direct-X/Y slow path the primary design**, not a follow-up. It is both faster and
+   simpler than the retraversal fallback.
+3. **Do not cap** the precompute.
+4. **Shard the precompute** across the fleet (17× → 29×).
+5. Gate on the existing `kernel_equiv_replay` full-stage harness, as every prior kernel change was.
+6. On §5 Q5 (is per-unit optimization the right frame): at ~29× a full sweep drops from ~3.6 min to
+   ~8 s fleet-wide, which makes a 500-stage wall ~1 hour instead of ~2 days. That is a large enough
+   change in the cost of a wall that it is worth taking *before* revisiting the move space — it
+   makes the strategic experiments cheaper to run.

--- a/src/main/java/com/setminusx/ramsey/mw/controller/FleetController.java
+++ b/src/main/java/com/setminusx/ramsey/mw/controller/FleetController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -44,12 +45,18 @@ public class FleetController {
      */
     @GetMapping("/{platform}/active-stage")
     public ResponseEntity<Stage> activeStage(@PathVariable String platform) {
+        // Resolve FIRST: it is cached, so the hot path (a running fleet, hit once per work cycle
+        // by every worker) costs no database round trip at all. The existence check is only
+        // needed to tell an unknown platform (404) from an idle one (204), which is exactly the
+        // case where the resolution came back empty — so it stays off the hot path.
+        Optional<Stage> stage = fleetService.resolveActiveStage(platform);
+        if (stage.isPresent()) {
+            return ResponseEntity.ok(stage.get());
+        }
         if (fleetService.get(platform).isEmpty()) {
             throw new ResponseStatusException(NOT_FOUND, "Fleet not found: " + platform);
         }
-        return fleetService.resolveActiveStage(platform)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.noContent().build());
+        return ResponseEntity.noContent().build();
     }
 
     @PutMapping("/{platform}")

--- a/src/main/java/com/setminusx/ramsey/mw/dto/ProgressionDTO.java
+++ b/src/main/java/com/setminusx/ramsey/mw/dto/ProgressionDTO.java
@@ -17,4 +17,5 @@ public class ProgressionDTO {
     private Integer cliqueCount;
     private LocalDateTime createdDate;
     private Stage.Status status;
+    private String details; // e.g. "PERTURBATION kick from graph ..." — lets consumers identify kick stages
 }

--- a/src/main/java/com/setminusx/ramsey/mw/repository/StageRepo.java
+++ b/src/main/java/com/setminusx/ramsey/mw/repository/StageRepo.java
@@ -29,7 +29,7 @@ public interface StageRepo extends JpaRepository<Stage, Integer> {
                         @Param("status") Stage.Status status,
                         Pageable pageable);
 
-        @Query("SELECT new com.setminusx.ramsey.mw.dto.ProgressionDTO(s.stageId, s.baseGraphId, g.cliqueCount, s.createdDate, s.status) "
+        @Query("SELECT new com.setminusx.ramsey.mw.dto.ProgressionDTO(s.stageId, s.baseGraphId, g.cliqueCount, s.createdDate, s.status, s.details) "
                         +
                         "FROM Stage s, Graph g " +
                         "WHERE s.baseGraphId = g.graphId " +

--- a/src/main/java/com/setminusx/ramsey/mw/service/FleetService.java
+++ b/src/main/java/com/setminusx/ramsey/mw/service/FleetService.java
@@ -8,14 +8,36 @@ import com.setminusx.ramsey.mw.repository.StageRepo;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @lombok.RequiredArgsConstructor
 public class FleetService {
 
+    /**
+     * How long a resolved active stage may be served from memory.
+     *
+     * {@link #resolveActiveStage} is the fleet's hot path — every worker calls it once per work
+     * cycle, so it runs tens of times a second and each call is two DB round trips. The answer
+     * only changes when a stage advances (seconds apart) or an operator repoints a fleet, and the
+     * latter evicts explicitly, so a very short TTL removes almost all of that load while bounding
+     * how long a worker can be handed a stage that has just been superseded. Kept well under a
+     * worker's batch duration so it is never the dominant source of staleness.
+     */
+    private static final long ACTIVE_STAGE_CACHE_MILLIS = 250;
+
     private final FleetRepo fleetRepo;
     private final StageRepo stageRepo;
+
+    private record CachedStage(Optional<Stage> stage, long expiresAtNanos) {
+        boolean isFresh() {
+            return System.nanoTime() < expiresAtNanos;
+        }
+    }
+
+    private final Map<String, CachedStage> activeStageCache = new ConcurrentHashMap<>();
 
     public List<Fleet> list() {
         return fleetRepo.findAll();
@@ -35,12 +57,33 @@ public class FleetService {
      * Distinguish 404 from 204 with {@link #get(String)} for existence.
      */
     public Optional<Stage> resolveActiveStage(String platform) {
+        CachedStage cached = activeStageCache.get(platform);
+        if (cached != null && cached.isFresh()) {
+            return cached.stage();
+        }
+        Optional<Stage> resolved = resolveActiveStageUncached(platform);
+        activeStageCache.put(platform, new CachedStage(
+                resolved, System.nanoTime() + ACTIVE_STAGE_CACHE_MILLIS * 1_000_000L));
+        return resolved;
+    }
+
+    /** The real lookup, bypassing the cache. Visible for tests. */
+    Optional<Stage> resolveActiveStageUncached(String platform) {
         Fleet fleet = fleetRepo.findById(platform).orElse(null);
         if (fleet == null || fleet.getStatus() == Fleet.Status.PAUSED || fleet.getCampaignId() == null) {
             return Optional.empty();
         }
         return stageRepo.findByCampaignIdAndStatus(fleet.getCampaignId(), Stage.Status.ACTIVE)
                 .stream().findFirst();
+    }
+
+    /**
+     * Drop a fleet's cached resolution. Called whenever the mapping or status changes so that
+     * pausing, resuming or repointing a fleet takes effect on the very next worker poll rather
+     * than after the TTL — operators expect those to be immediate.
+     */
+    private void evict(String platform) {
+        activeStageCache.remove(platform);
     }
 
     /** Upsert a fleet with a partial update (only supplied fields change). */
@@ -60,13 +103,17 @@ public class FleetService {
         if (req.getNote() != null) {
             fleet.setNote(req.getNote());
         }
-        return fleetRepo.save(fleet);
+        Fleet saved = fleetRepo.save(fleet);
+        evict(platform);
+        return saved;
     }
 
     public Optional<Fleet> setStatus(String platform, Fleet.Status status) {
         return fleetRepo.findById(platform).map(fleet -> {
             fleet.setStatus(status);
-            return fleetRepo.save(fleet);
+            Fleet saved = fleetRepo.save(fleet);
+            evict(platform);
+            return saved;
         });
     }
 }

--- a/src/main/java/com/setminusx/ramsey/mw/service/FleetService.java
+++ b/src/main/java/com/setminusx/ramsey/mw/service/FleetService.java
@@ -20,11 +20,17 @@ public class FleetService {
      * How long a resolved active stage may be served from memory.
      *
      * {@link #resolveActiveStage} is the fleet's hot path — every worker calls it once per work
-     * cycle, so it runs tens of times a second and each call is two DB round trips. The answer
-     * only changes when a stage advances (seconds apart) or an operator repoints a fleet, and the
-     * latter evicts explicitly, so a very short TTL removes almost all of that load while bounding
-     * how long a worker can be handed a stage that has just been superseded. Kept well under a
-     * worker's batch duration so it is never the dominant source of staleness.
+     * cycle, so it runs tens of times a second. The answer only changes when a stage advances or
+     * an operator repoints a fleet, and the latter evicts explicitly, so a very short TTL removes
+     * almost all of that load while bounding how long a worker can be handed a stage that has just
+     * been superseded.
+     *
+     * Only a RESOLVED stage is cached. An empty answer is deliberately never cached: a stage
+     * advance briefly leaves a campaign with no ACTIVE stage, and a worker that sees that gap
+     * treats the fleet as paused and drops its cached graph and hoist tables — which costs a full
+     * rebuild. During a post-kick descent stages turn over faster than this TTL, so caching the
+     * gap would stretch a millisecond-wide race into a quarter-second outage. Re-reading is cheap
+     * now that the stage table is indexed (0.135ms).
      */
     private static final long ACTIVE_STAGE_CACHE_MILLIS = 250;
 
@@ -62,8 +68,12 @@ public class FleetService {
             return cached.stage();
         }
         Optional<Stage> resolved = resolveActiveStageUncached(platform);
-        activeStageCache.put(platform, new CachedStage(
-                resolved, System.nanoTime() + ACTIVE_STAGE_CACHE_MILLIS * 1_000_000L));
+        if (resolved.isPresent()) {
+            activeStageCache.put(platform, new CachedStage(
+                    resolved, System.nanoTime() + ACTIVE_STAGE_CACHE_MILLIS * 1_000_000L));
+        } else {
+            activeStageCache.remove(platform);
+        }
         return resolved;
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,11 +7,13 @@ spring:
     init:
       mode: ${SQL_INIT_MODE:never} # Runs data.sql for inserts [never, always]
   datasource:
-    url: jdbc:mysql://ramsey-db-mysql:3306/ramsey-dev?autoReconnect=true&useSSL=false&rewriteBatchedStatements=true&allowPublicKeyRetrieval=true&cachePrepStmts=true&prepStmtCacheSize=250&prepStmtCacheSqlLimit=2048&useServerPrepStmts=true
+    url: jdbc:mysql://ramsey-db-mysql:3306/ramsey-dev?autoReconnect=true&useSSL=false&rewriteBatchedStatements=true&allowPublicKeyRetrieval=true&cachePrepStmts=true&prepStmtCacheSize=250&prepStmtCacheSqlLimit=2048&useServerPrepStmts=true&useLocalSessionState=true&cacheServerConfiguration=true&maintainTimeStats=false
     username: ${DB_USER}
     password: ${DB_PASS}
     hikari:
-      maximum-pool-size: 20
+      # Max_used_connections reached 21 against a ceiling of 20, i.e. the pool has saturated and
+      # queued at least once. Server max_connections is 151, so there is ample room.
+      maximum-pool-size: 30
       minimum-idle: 5
       idle-timeout: 300000
       connection-timeout: 30000

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,7 +7,7 @@ spring:
     init:
       mode: ${SQL_INIT_MODE:never} # Runs data.sql for inserts [never, always]
   datasource:
-    url: jdbc:mysql://127.0.0.1:36001/ramsey-dev?autoReconnect=true&useSSL=false&rewriteBatchedStatements=true&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://127.0.0.1:36001/ramsey-dev?autoReconnect=true&useSSL=false&rewriteBatchedStatements=true&allowPublicKeyRetrieval=true&useLocalSessionState=true&cacheServerConfiguration=true&maintainTimeStats=false&cachePrepStmts=true&prepStmtCacheSize=250&prepStmtCacheSqlLimit=2048&useServerPrepStmts=true
     username: ${DB_USER}
     password: ${DB_PASS}
   data:

--- a/src/test/java/com/setminusx/ramsey/mw/service/FleetServiceTest.java
+++ b/src/test/java/com/setminusx/ramsey/mw/service/FleetServiceTest.java
@@ -134,16 +134,33 @@ class FleetServiceTest {
         verify(fleetRepo, times(1)).findById("m4-max");
     }
 
-    /** An idle fleet must be cached too, or a paused fleet still hammers the DB every cycle. */
+    /**
+     * An empty answer must NOT be cached. A stage advance briefly leaves a campaign with no ACTIVE
+     * stage, and a worker seeing that gap treats the fleet as paused and drops its cached graph and
+     * hoist tables. Caching the gap would stretch a millisecond race into the full TTL — which,
+     * during a descent, is longer than a whole stage.
+     */
     @Test
-    void resolveActiveStage_cachesTheEmptyResult() {
+    void resolveActiveStage_doesNotCacheTheEmptyResult() {
         when(fleetRepo.findById("m1")).thenReturn(Optional.of(fleet(10, Fleet.Status.PAUSED)));
 
         for (int i = 0; i < 10; i++) {
             assertTrue(service.resolveActiveStage("m1").isEmpty());
         }
-        verify(fleetRepo, times(1)).findById("m1");
-        verifyNoInteractions(stageRepo);
+        verify(fleetRepo, times(10)).findById("m1");
+    }
+
+    /** A stage appearing after a gap must be visible immediately, not after the TTL. */
+    @Test
+    void stageAppearingAfterAGapIsVisibleImmediately() {
+        when(fleetRepo.findById("m4-max")).thenReturn(Optional.of(fleet(10, Fleet.Status.RUNNING)));
+        when(stageRepo.findByCampaignIdAndStatus(10, Stage.Status.ACTIVE)).thenReturn(List.of());
+        assertTrue(service.resolveActiveStage("m4-max").isEmpty()); // mid-advance gap
+
+        when(stageRepo.findByCampaignIdAndStatus(10, Stage.Status.ACTIVE))
+                .thenReturn(List.of(activeStage(10)));
+        assertTrue(service.resolveActiveStage("m4-max").isPresent(),
+                "a new stage must not be hidden by a cached gap");
     }
 
     /** Pausing must take effect on the next poll, not after the TTL. */

--- a/src/test/java/com/setminusx/ramsey/mw/service/FleetServiceTest.java
+++ b/src/test/java/com/setminusx/ramsey/mw/service/FleetServiceTest.java
@@ -117,4 +117,83 @@ class FleetServiceTest {
         assertEquals("vast-ai", created.getPlatform());
         assertEquals(10, created.getCampaignId());
     }
+
+    // ---------- active-stage caching (the fleet hot path) ----------
+
+    @Test
+    void resolveActiveStage_isCachedWithinTheTtl() {
+        when(fleetRepo.findById("m4-max")).thenReturn(Optional.of(fleet(10, Fleet.Status.RUNNING)));
+        when(stageRepo.findByCampaignIdAndStatus(10, Stage.Status.ACTIVE))
+                .thenReturn(List.of(activeStage(10)));
+
+        for (int i = 0; i < 25; i++) {
+            assertEquals(999, service.resolveActiveStage("m4-max").orElseThrow().getStageId());
+        }
+        // Every worker calls this once per cycle; it must not be one DB round trip per call.
+        verify(stageRepo, times(1)).findByCampaignIdAndStatus(10, Stage.Status.ACTIVE);
+        verify(fleetRepo, times(1)).findById("m4-max");
+    }
+
+    /** An idle fleet must be cached too, or a paused fleet still hammers the DB every cycle. */
+    @Test
+    void resolveActiveStage_cachesTheEmptyResult() {
+        when(fleetRepo.findById("m1")).thenReturn(Optional.of(fleet(10, Fleet.Status.PAUSED)));
+
+        for (int i = 0; i < 10; i++) {
+            assertTrue(service.resolveActiveStage("m1").isEmpty());
+        }
+        verify(fleetRepo, times(1)).findById("m1");
+        verifyNoInteractions(stageRepo);
+    }
+
+    /** Pausing must take effect on the next poll, not after the TTL. */
+    @Test
+    void pause_evictsImmediately() {
+        when(fleetRepo.findById("m4-max"))
+                .thenReturn(Optional.of(fleet(10, Fleet.Status.RUNNING)));
+        when(stageRepo.findByCampaignIdAndStatus(10, Stage.Status.ACTIVE))
+                .thenReturn(List.of(activeStage(10)));
+        assertTrue(service.resolveActiveStage("m4-max").isPresent());
+
+        Fleet paused = fleet(10, Fleet.Status.PAUSED);
+        when(fleetRepo.findById("m4-max")).thenReturn(Optional.of(paused));
+        when(fleetRepo.save(any(Fleet.class))).thenReturn(paused);
+        service.setStatus("m4-max", Fleet.Status.PAUSED);
+
+        assertTrue(service.resolveActiveStage("m4-max").isEmpty(),
+                "pause must be visible on the very next resolve");
+    }
+
+    /** Repointing a fleet to another campaign must take effect immediately too. */
+    @Test
+    void update_evictsImmediately() {
+        when(fleetRepo.findById("m4-max"))
+                .thenReturn(Optional.of(fleet(10, Fleet.Status.RUNNING)));
+        when(stageRepo.findByCampaignIdAndStatus(10, Stage.Status.ACTIVE))
+                .thenReturn(List.of(activeStage(10)));
+        assertEquals(10, service.resolveActiveStage("m4-max").orElseThrow().getCampaignId());
+
+        Fleet repointed = fleet(11, Fleet.Status.RUNNING);
+        when(fleetRepo.findById("m4-max")).thenReturn(Optional.of(repointed));
+        when(fleetRepo.save(any(Fleet.class))).thenReturn(repointed);
+        when(stageRepo.findByCampaignIdAndStatus(11, Stage.Status.ACTIVE))
+                .thenReturn(List.of(activeStage(11)));
+        FleetUpdateRequest req = new FleetUpdateRequest();
+        req.setCampaignId(11);
+        service.update("m4-max", req);
+
+        assertEquals(11, service.resolveActiveStage("m4-max").orElseThrow().getCampaignId());
+    }
+
+    /** The cache must not leak across fleets. */
+    @Test
+    void cacheIsPerPlatform() {
+        when(fleetRepo.findById("m4-max")).thenReturn(Optional.of(fleet(10, Fleet.Status.RUNNING)));
+        when(stageRepo.findByCampaignIdAndStatus(10, Stage.Status.ACTIVE))
+                .thenReturn(List.of(activeStage(10)));
+        when(fleetRepo.findById("m1")).thenReturn(Optional.of(fleet(10, Fleet.Status.PAUSED)));
+
+        assertTrue(service.resolveActiveStage("m4-max").isPresent());
+        assertTrue(service.resolveActiveStage("m1").isEmpty());
+    }
 }


### PR DESCRIPTION
Performance work on the middleware and the deployment, plus the hoist proposal and its measured review.

## Index the stage table

The fleet active-stage lookup is the hot path of the whole system — every worker calls it once per work cycle — and `stage` had no index beyond its primary key, so each call was a full table scan. The table grows one row per stage advance, so the cost climbed without bound. It was ~44% of MySQL's CPU and the dominant term in the worker's fixed per-cycle overhead.

```
idx_stage_campaign_status (campaign_id, status)   -> the active-stage lookup
idx_stage_campaign_stage  (campaign_id, stage_id) -> MAX(stage_id), progression scans
```

Measured: **11.84 ms -> 0.135 ms** (table scan of 64,309 rows -> covering index lookup of 1), `MAX(stage_id)` 11.03 ms -> 0.085 ms, endpoint 25-43 ms -> 1.2-2.1 ms. Applied to the live DB and added to all three schemas in `init-script.ddl`.

## Cache the fleet's active-stage resolution

250 ms TTL, with explicit eviction on update/setStatus so pause/resume/repoint stay immediate. The controller now resolves BEFORE the existence check — that check only distinguishes 404 from 204, which is exactly the case where resolution came back empty, so it no longer costs an uncached query on every hot-path call.

An empty resolution is deliberately never cached: a stage advance briefly leaves a campaign with no ACTIVE stage, and a worker seeing that gap drops its cached graph and hoist tables. During a descent stages turn over faster than the TTL, so caching the gap would stretch a millisecond race into a quarter-second outage.

## JDBC tuning

Measured on the live DB, essentially ALL statement traffic was transaction ceremony rather than queries: `SET autocommit` 85.8/s, `SET SESSION TRANSACTION READ ONLY/READ WRITE` 37.6/s each, `COMMIT` 42.9/s, against ~0/s of real SELECTs. Added `useLocalSessionState` / `cacheServerConfiguration`; pool 20 -> 30 (`Max_used_connections` had reached 21).

**Net across all of the above: database statements 204/s -> 105/s, MySQL CPU 44% -> ~18%.**

## Deployment

`WORK_UNIT_FETCH_COUNT` is now a batch FLOOR, not a size — the worker resizes from measured throughput. It must stay low enough that a batch fits inside a stage. Also swaps `PERTURBATION_WALL_STAGES` for `PERTURBATION_BASIN_STALE_STAGES` and makes the `HOIST_ENABLED` kill switch explicit.

## Docs

`docs/investigations/pair-move-hoist-proposal.md` and a measured review of it, which found a shared-vertex bug in the proposal's pseudocode and established the real speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7XjzEBwfnWeVv9KRSrWWr