### PR TITLE
docs: bring investigation and worker docs up to date after the hoist

### DIFF
--- a/docs/investigations/README.md
+++ b/docs/investigations/README.md
@@ -1,6 +1,6 @@
 # Investigations — index
 
-Goal throughout: a 282-vertex 2-coloring with zero monochromatic K₈ ⇒ **R(8,8) ≥ 283**. Best-known 282-graph: **25,840** mono-8 (graph 8644, 2026-06-16).
+Goal throughout: a 282-vertex 2-coloring with zero monochromatic K₈ ⇒ **R(8,8) ≥ 283**. Best-known 282-graph: **25,758** mono-8 (graph 26994, set by a perturbation kick on campaign 10). The older 25,840 (graph 8644) is still referenced by pre-July docs.
 
 **Start here:** `july-2026-next-steps.md` (live roadmap) → `search-status-2026-06-14.md` (consolidated findings + do-not-retry list).
 
@@ -9,7 +9,9 @@ Goal throughout: a 282-vertex 2-coloring with zero monochromatic K₈ ⇒ **R(8,
 | Doc | What it is |
 |---|---|
 | `july-2026-next-steps.md` | **Live roadmap** — multi-seed basin program (campaigns 11+), ranked queue |
-| `fleet-abstraction-plan.md` | **PLANNED (Phase 1)** — replace `RAMSEY_CAMPAIGN_ID` env-pinning with a DB `fleet` table (platform→campaign); single campaign-agnostic QM; remove `campaign.status`. Repointing becomes a DB update, not a redeploy. Phase 2 (perturbation/ILS) builds on it. |
+| `fleet-abstraction-plan.md` | **SHIPPED** — `RAMSEY_CAMPAIGN_ID` env-pinning replaced by a DB `fleet` table (platform→campaign); single campaign-agnostic QM. Repointing/pausing is a DB update, not a redeploy. Phase 2 (perturbation/ILS) built on it and is also live. |
+| `pair-move-hoist-proposal.md` | **SHIPPED** — the original proposal for hoisting per-edge clique counts out of the pair-move inner loop |
+| `pair-move-hoist-review.md` | **SHIPPED** — measured review of that proposal (found a shared-vertex bug in its pseudocode), plus the outcome: what the kernel change actually bought once the surrounding bottlenecks were removed |
 | `search-status-2026-06-14.md` | Consolidated June findings hub; do-not-retry list; supersedes older strategy docs |
 | `structurally-new-base-investigation.md` | All construction families certified empty: cyclotomic (every prime order ≤ **1021**; p ≡ 3 mod 4 closed by parity theorem), Seidel switching, all four order-282 Cayley groups |
 | `windowed-maxsat-investigation.md` | Exact (complete-solver) windowed MaxSAT: ~1.1M proven-optimal windows, zero escapes, |F| up to 128 |

--- a/docs/investigations/july-2026-next-steps.md
+++ b/docs/investigations/july-2026-next-steps.md
@@ -8,7 +8,26 @@
 
 ---
 
-## CURRENT STATE (2026-07-15) — read this before the dated snapshot below
+## CURRENT STATE (2026-07-26) — read this first; everything below is an older snapshot
+
+- **All-time best is now 25,758** (graph 26994), set by a perturbation kick on campaign 10 —
+  the first time anything has beaten the long-standing 25,840. Still not a witness (≠ 0).
+- **Perturbation kicks now fire on BASIN STALENESS, not a fixed wall.** The clock runs from the
+  basin's own floor, so a descent still finding new minima is never cut off. The old fixed
+  `PERTURBATION_WALL_STAGES` truncated seven campaign-10 descents mid-free-fall.
+  `PERTURBATION_BASIN_STALE_STAGES` is 500 (the gap between successive new basin minima reaches
+  249 stages near the floor, so a smaller window kicks basins before they reach their floor).
+- **The exhaustive worker no longer traverses for most work units.** `created` is derived
+  algebraically from memoised per-edge counts (`hoist.rs`); ~86% of pairs need no traversal at
+  all. See `pair-move-hoist-review.md` for the measured outcome.
+- **Fleet throughput is now measured in the tens of millions of units/sec**, up from ~1M. A full
+  392M-unit sweep takes seconds rather than minutes, which changed what "a stage" costs and
+  invalidated several constants sized for the old regime (batch size, exhaustion delay, the
+  hoist gate). Expect that to keep happening: every speedup relocates the bottleneck.
+- **Storage is now the growth constraint** — the `graph` table adds ~6 GB/day at current stage
+  rates. No retention policy yet.
+
+## EARLIER SNAPSHOT (2026-07-15)
 
 - **Multi-seed basin program: COMPLETE.** Six basin floors (25,840 / 25,881 / 25,996 / 26,185 / 26,385 / 26,677), none below the original 25,840. Full result: `multiseed-basin-program-results.md`.
 - **Deep-wall re-runs (decision #1) in progress.** c11 (25,881) **confirmed terminal** — re-ran a censored basin to a full 500-stage wall, found nothing. c13 (25,996) re-run running now on the M4-Max fleet. M1 stays on campaign 10.

--- a/docs/investigations/pair-move-hoist-proposal.md
+++ b/docs/investigations/pair-move-hoist-proposal.md
@@ -1,6 +1,9 @@
 # Proposal: hoist per-edge clique counts out of the pair-move inner loop
 
-**Status:** proposal, not implemented. Seeking review before building.
+**Status: SHIPPED 2026-07-26.** Reviewed, corrected, built and deployed — see
+`pair-move-hoist-review.md` for the measured review (which found a bug in §2's pseudocode) and the
+outcome. This document is kept as the original proposal; where it disagrees with the review, the
+review is right.
 **Date:** 2026-07-25
 **Expected gain:** ~5–15× worker throughput in the regime the search currently lives in.
 **Risk profile:** the change is *exact* (bit-identical results), so the risk is implementation bugs, not lost search quality.

--- a/docs/investigations/pair-move-hoist-review.md
+++ b/docs/investigations/pair-move-hoist-review.md
@@ -7,7 +7,35 @@
 (`get_new_cliques_with_limit`) and the shipped `CliqueCollection` / enumerators, so "production"
 in every table below is the real thing, not a re-implementation.
 
-## Verdict
+## Outcome (2026-07-26) — built, deployed, and measured
+
+Shipped as `ramsey-worker-rust/src/hoist.rs`. What the review got right, and what it missed:
+
+| Review said | Actually happened |
+|---|---|
+| identity is exact | confirmed — full-stage replay over all 392,495,529 units, zero mismatches |
+| §2 pseudocode mishandles shared-vertex pairs | confirmed — fixed before shipping |
+| fast path 86.32% | confirmed live |
+| ~29× on a sweep | the kernel win was real but **invisible until the plumbing was fixed** |
+| don't cap the precompute | held |
+| shard the fill | built; 31–81% of the table now comes from peers |
+
+**The reviewer's biggest miss:** it treated ~29× as the deliverable. In production the kernel gain
+was hidden behind fixed per-cycle costs that had never mattered before, and each one had to be
+found and removed in turn — a full-table-scan on `stage` (11.8ms → 0.135ms with an index), a
+per-cycle fleet HTTP call, a batch size that could not adapt, and finally a 1-second sleep on
+transient stage races that left the fleet at 19% CPU. That last one was a pre-existing bug that
+only became reachable once stages advanced quickly.
+
+Lesson worth carrying: **making one stage of a pipeline 30× faster does not make the pipeline
+faster; it relocates the bottleneck, usually somewhere nobody was measuring.**
+
+Also of note: two of the review's own conclusions were later overturned by better measurement —
+`MAX_INCREMENTAL_FLIPS` ("not worth changing", measured only in the wall, actually 51% fallback in
+descents) and the sharded fill ("3% peer coverage", which turned out to be a broken metric reading
+the pre-publish sweep). Both were caught by checking ground truth rather than the instrument.
+
+## Verdict (as written at review time)
 
 **Build it — the approach is sound and worth substantially more than proposed.** Measured
 **~29× on a full stage sweep** (single core), versus the proposal's 6.5×–15× estimate.

--- a/docs/workers/exhaustive-worker.md
+++ b/docs/workers/exhaustive-worker.md
@@ -32,16 +32,44 @@ Edge pairs can be enumerated in different orders, controlled by `WORK_ENUMERATIO
 For each edge pair, the worker computes the resulting clique count using an incremental approach:
 
 1. Look up how many existing cliques contain the edges being flipped (the "broken" count) from the pre-built `CliqueCollection`.
-2. Temporarily flip the edges on the working graph.
-3. Run seeded Bron-Kerbosch to count new cliques formed by the flip.
-4. Compute: `new_total = base_total - broken + new_cliques`.
-5. Unflip the edges to restore the graph.
+2. Compute `created` — the cliques the flip forms. **Since 2026-07-26 this is normally derived
+   algebraically rather than traversed** (see below).
+3. Compute: `new_total = base_total - broken + created`.
+
+### Deriving `created` without traversing (`hoist.rs`)
+
+A pair move flips red edge `r` and blue edge `b`, so `R' = (R ∪ {b}) \ {r}` and
+`B' = (B ∪ {r}) \ {b}`. Only a newly-coloured edge can be in a new clique, giving
+
+```
+created = (C_b − X) + (D_r − Y)
+```
+
+where `C_b` / `D_r` depend on ONE edge and the base graph — exactly what flipping that edge alone
+would create — and `X` / `Y` count cliques containing BOTH edges. A clique containing both must
+contain every vertex of both, so all its internal pairs share a colour: `X > 0` needs the cross
+pairs all red, `Y > 0` needs them all blue, and when they are mixed BOTH vanish. **That fast path
+is ~86% of the pair space and needs no traversal at all.** The correction, when needed, seeds on
+the 3–4 forced vertices and needs no graph mutation either.
+
+`C_b` / `D_r` are memoised per base graph and filled co-operatively: each worker computes one
+slice of the edge space and publishes it to Redis, keyed by GRAPH id, so a fleet pools the work.
+The table is a memo, so a missing slice costs time and never correctness.
+
+The seeded Bron-Kerbosch path (`get_new_cliques_with_limit`) remains as the fallback and as the
+reference the hoisted path is validated against — bit-identical over a full 392M-unit stage. Set
+`HOIST_ENABLED=false` to run on it exclusively.
 
 The `CliqueCollection` is built once per stage by enumerating all cliques of the target size (8-cliques for 282 vertices) using a comprehensive Bron-Kerbosch pass. It provides O(1) lookup of which cliques contain a given edge, enabling the incremental formula above.
 
 ### Early Termination
 
 When `PUBLISH_RESULTS=false` (the default for local deployments), the worker uses early termination during Bron-Kerbosch. If the new clique count exceeds the current top-N threshold, enumeration stops immediately. This dramatically reduces computation for clearly-bad mutations -- the worker only does full counting for mutations that have a chance of being competitive.
+
+On the hoisted path there is nothing to terminate early: `created` is computed exactly from table
+lookups, so the abort the kernel would have taken becomes a single comparison. The bound-skip that
+precedes both paths (reject from the per-edge counts alone, before any evaluation) still applies
+and does most of the work mid-descent.
 
 ### Top-N Result Tracking
 


### PR DESCRIPTION
The hoist shipping invalidated a fair amount of documentation.

- **`pair-move-hoist-proposal.md`** still said *"proposal, not implemented"*. Banner-marked SHIPPED, deferring to the review where the two disagree.
- **`pair-move-hoist-review.md`** ended at "build it". It now carries the outcome — including where the review itself was wrong. It treated ~29× as the deliverable, when in production the kernel gain was invisible until a chain of fixed per-cycle costs was found and removed one at a time (a full-table scan on `stage`, a per-cycle HTTP call, a non-adaptive batch size, and a 1-second sleep on stage races that left the fleet at 19% CPU). Two of the review's own conclusions — `MAX_INCREMENTAL_FLIPS` and the sharded-fill coverage — were later overturned by better measurement, and that's recorded.
- **`investigations/README.md`** claimed the best-known 282-graph was **25,840 (graph 8644)**. It is **25,758 (graph 26994)**. Fleet abstraction was listed as PLANNED; it is shipped. Both hoist docs are now indexed.
- **`july-2026-next-steps.md`** led with a July-15 "current state"; a July-26 section now precedes it.
- **`workers/exhaustive-worker.md`** described clique evaluation as *"run seeded Bron-Kerbosch to count new cliques"* — that is now the FALLBACK. Documents the algebraic derivation, the ~86% no-traversal fast path, and the co-operative fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7XjzEBwfnWeVv9KRSrWWr