### PR TITLE
Accept SEQUENTIAL_WITH_SINGLES, and switch the fleet to it

### DIFF
--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -65,7 +65,12 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       WORK_UNIT_ANALYSIS_TYPE: TARGETED
-      WORK_ENUMERATION_STRATEGY: "DUAL_EDGE_CARDINALITY_WITH_SINGLES"  # singles census (majority color) + counter-based pair sweep
+      # Singles census + counter-based pair sweep, in plain edge order. The cardinality ordering
+      # this replaces cost 13.5ms per stage per worker to build and existed to sweep likely
+      # improvements first — which mattered when a sweep took ~233s and a stage only ever saw part
+      # of its space. A sweep is now ~6s, stages routinely reach most of it, and the QM adopts the
+      # best of the top-50 rather than the first found, so the order no longer changes the outcome.
+      WORK_ENUMERATION_STRATEGY: "SEQUENTIAL_WITH_SINGLES"
       TOP_RESULTS_COUNT: 50
       STAGE_ADOPT_SETTLE_MS: 100      # pub/sub-armed settle window; 0 = pure polling
       # Grace period for in-flight workers once a stage's work is fully CLAIMED but not yet fully

--- a/src/main/java/com/setminusx/ramsey/mw/entity/Stage.java
+++ b/src/main/java/com/setminusx/ramsey/mw/entity/Stage.java
@@ -48,7 +48,17 @@ public class Stage {
         BASIC,
         SINGLE_EDGE_CARDINALITY,
         DUAL_EDGE_CARDINALITY,
-        DUAL_EDGE_CARDINALITY_WITH_SINGLES
+        DUAL_EDGE_CARDINALITY_WITH_SINGLES,
+        /**
+         * Singles then pairs in plain edge order — same work space as
+         * DUAL_EDGE_CARDINALITY_WITH_SINGLES, no cardinality scoring or sort.
+         *
+         * Every service that persists or validates this name needs to know it: the queue manager
+         * matches on the string to size the work space, the worker deserializes it into its own
+         * enum, and THIS enum decides whether a stage POST is accepted at all. Adding a value to
+         * only some of them rejects every stage creation with a 400 and stalls the search.
+         */
+        SEQUENTIAL_WITH_SINGLES
     }
 
 }

--- a/src/test/java/com/setminusx/ramsey/mw/entity/StageStrategyTest.java
+++ b/src/test/java/com/setminusx/ramsey/mw/entity/StageStrategyTest.java
@@ -1,0 +1,28 @@
+package com.setminusx.ramsey.mw.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * The strategy name crosses three services: the queue manager matches on the string to size the
+ * work space, the worker deserializes it, and this enum decides whether a stage POST is accepted.
+ * A name missing here rejects every stage creation with a 400 and stalls the search outright, so
+ * pin the set rather than relying on all three being updated together.
+ */
+class StageStrategyTest {
+
+    @Test
+    void everyStrategyTheFleetCanBeConfiguredWithIsAccepted() {
+        for (String name : new String[] {
+                "BASIC",
+                "SINGLE_EDGE_CARDINALITY",
+                "DUAL_EDGE_CARDINALITY",
+                "DUAL_EDGE_CARDINALITY_WITH_SINGLES",
+                "SEQUENTIAL_WITH_SINGLES",
+        }) {
+            assertDoesNotThrow(() -> Stage.WorkEnumerationStrategy.valueOf(name),
+                    "middleware rejects strategy " + name + " — stage creation would 400");
+        }
+    }
+}


### PR DESCRIPTION
Same work space as `DUAL_EDGE_CARDINALITY_WITH_SINGLES` — every edge as a single flip, then every (red, blue) pair — but in plain edge order, with no cardinality scoring and no sort.

**Measured on a live graph: 13.47 ms → 89 µs to build, 151× cheaper**, for an identical 392,495,531-unit space.

The ordering existed to sweep likely-improving moves first. That mattered when a sweep took ~233 s and a stage only ever saw part of its space. A sweep is now ~6 s, stages routinely reach most or all of it, and the QM adopts the best of the top-50 rather than the first found — so the order no longer changes which result is adopted. The closest measured analogue of the heuristic (participation rank) backtested at **zero signal** against 4,637 real winners.

Plain edge order should also suit the hoisted path better: consecutive units walk consecutive blue edges, whose per-edge table entries are adjacent in memory.

⚠️ **The strategy name crosses three services and each holds it differently** — the QM matches on the string to size the work space, the worker deserializes it into its own enum, and the middleware's entity enum decides whether a stage POST is accepted at all. Adding it to only some of them rejects every stage creation with a 400. Tests now pin this on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7XjzEBwfnWeVv9KRSrWWr