### PR TITLE
Bring the remote worker configs up to date with the main fleet

### DIFF
--- a/docker/aws/ec2-user-data.sh
+++ b/docker/aws/ec2-user-data.sh
@@ -33,14 +33,23 @@ services:
     image: benferenchak/ramsey-worker-rust:develop-neoverse-v2
     environment:
       RAMSEY_API_URL: http://www.setminusx.cloud:36000/api/ramsey
+      # LEGACY targeting. Campaign 1 has had no active stage since 2026-04-19, so this box will
+      # find no work as configured. The current mechanism is RAMSEY_FLEET; switching needs a
+      # fleet row for this platform to exist first.
       RAMSEY_CAMPAIGN_ID: 1
       REDIS_HOST: www.setminusx.cloud
       REDIS_PORT: 36002
-      WORK_UNIT_FETCH_COUNT: 50000
+      # FLOOR for the work range claimed per cycle, not a fixed size — the worker resizes each
+      # cycle from measured throughput. It must stay small enough that a batch fits INSIDE a
+      # stage; too large and every batch is abandoned partway when the stage advances.
+      WORK_UNIT_FETCH_COUNT: 2000
       WORK_UNIT_PUBLISH_COUNT: 10000
       WORK_UNIT_POLL_FREQ: 5000
       PUBLISH_RESULTS: "false"
-      TOP_RESULTS_COUNT: 10
+      TOP_RESULTS_COUNT: 50    # must match the QM of whatever campaign this targets
+      # Kill switch for the hoisted pair-move evaluation. The hoisted and seeded paths compute
+      # identical values, so this only ever trades cost.
+      HOIST_ENABLED: "true"
       WORKER_COUNT: 1
     logging:
       driver: loki

--- a/docker/dell-worker/ramsey-compose.yml
+++ b/docker/dell-worker/ramsey-compose.yml
@@ -6,14 +6,24 @@ services:
     image: benferenchak/ramsey-worker-rust:develop-amd64
     environment:
       RAMSEY_API_URL: http://ramsey-mw.setminusx.cloud/api/ramsey
+      # LEGACY targeting. Campaign 1 has had no active stage since 2026-04-19, so this box will
+      # find no work as configured. The current mechanism is RAMSEY_FLEET (a DB fleet->campaign
+      # mapping, repointed with PUT /fleets/{platform} and no redeploy); switching needs a fleet
+      # row for this platform to exist first.
       RAMSEY_CAMPAIGN_ID: 1
       REDIS_HOST: www.setminusx.cloud
       REDIS_PORT: 36002
-      WORK_UNIT_FETCH_COUNT: 50000
+      # FLOOR for the work range claimed per cycle, not a fixed size — the worker resizes each
+      # cycle from measured throughput. It must stay small enough that a batch fits INSIDE a
+      # stage; too large and every batch is abandoned partway when the stage advances.
+      WORK_UNIT_FETCH_COUNT: 2000
       WORK_UNIT_PUBLISH_COUNT: 10000
       WORK_UNIT_POLL_FREQ: 5000
       PUBLISH_RESULTS: "false"
-      TOP_RESULTS_COUNT: 10
+      TOP_RESULTS_COUNT: 50    # must match the QM of whatever campaign this targets
+      # Kill switch for the hoisted pair-move evaluation. The hoisted and seeded paths compute
+      # identical values, so this only ever trades cost.
+      HOIST_ENABLED: "true"
       WORKER_COUNT: 1
     logging:
       driver: loki

--- a/docker/m1-worker/ramsey-compose.yml
+++ b/docker/m1-worker/ramsey-compose.yml
@@ -9,11 +9,17 @@ services:
       RAMSEY_FLEET: m1   # fleet abstraction: target set in the DB `fleet` table (repoint via PUT /fleets/m1 from anywhere — no SSH needed)
       REDIS_HOST: www.setminusx.cloud
       REDIS_PORT: 36002
-      WORK_UNIT_FETCH_COUNT: 250000
+      # FLOOR for the work range claimed per cycle, not a fixed size — the worker resizes each
+      # cycle from measured throughput. It must stay small enough that a batch fits INSIDE a
+      # stage; too large and every batch is abandoned partway when the stage advances.
+      WORK_UNIT_FETCH_COUNT: 2000
       WORK_UNIT_PUBLISH_COUNT: 10000
       WORK_UNIT_POLL_FREQ: 1000
       PUBLISH_RESULTS: "false"
       TOP_RESULTS_COUNT: 50    # must match the campaign-10 QM (main compose)
+      # Kill switch for the hoisted pair-move evaluation. The hoisted and seeded paths compute
+      # identical values, so this only ever trades cost.
+      HOIST_ENABLED: "true"
       WORKER_COUNT: 1
     logging:
       driver: loki

--- a/docker/vast-ai/on-start.sh
+++ b/docker/vast-ai/on-start.sh
@@ -26,14 +26,22 @@ services:
     image: benferenchak/ramsey-worker-rust:develop-amd64
     environment:
       RAMSEY_API_URL: http://www.setminusx.cloud:36000/api/ramsey
-      RAMSEY_CAMPAIGN_ID: 1
+      # Fleet abstraction: the target is set in the DB `fleet` table and repointed with
+      # PUT /fleets/vast-ai — no redeploy, which matters for burst instances.
+      RAMSEY_FLEET: vast-ai
       REDIS_HOST: www.setminusx.cloud
       REDIS_PORT: 36002
-      WORK_UNIT_FETCH_COUNT: 50000
+      # FLOOR for the work range claimed per cycle, not a fixed size — the worker resizes each
+      # cycle from measured throughput. It must stay small enough that a batch fits INSIDE a
+      # stage; too large and every batch is abandoned partway when the stage advances.
+      WORK_UNIT_FETCH_COUNT: 2000
       WORK_UNIT_PUBLISH_COUNT: 10000
       WORK_UNIT_POLL_FREQ: 5000
       PUBLISH_RESULTS: "false"
-      TOP_RESULTS_COUNT: 10
+      TOP_RESULTS_COUNT: 50    # must match the QM of the campaign this fleet is mapped to
+      # Kill switch for the hoisted pair-move evaluation. The hoisted and seeded paths compute
+      # identical values, so this only ever trades cost.
+      HOIST_ENABLED: "true"
       WORKER_COUNT: 1
     logging:
       driver: loki


### PR DESCRIPTION
Only the main (m4-max) compose had been tracking the worker's configuration. The other four had drifted, in ways that would bite the moment they were used.

| config | `WORK_UNIT_FETCH_COUNT` | targeting | `TOP_RESULTS_COUNT` | `HOIST_ENABLED` |
|---|---|---|---|---|
| main | 2,000 ✅ | `RAMSEY_FLEET: m4-max` ✅ | 50 ✅ | ✅ |
| m1-worker | **250,000** ❌ | `RAMSEY_FLEET: m1` ✅ | 50 ✅ | missing |
| dell-worker | 50,000 ❌ | `RAMSEY_CAMPAIGN_ID: 1` ⚠️ | **10** ❌ | missing |
| vast-ai | 50,000 ❌ | `RAMSEY_CAMPAIGN_ID: 1` ⚠️ | **10** ❌ | missing |
| aws | 50,000 ❌ | `RAMSEY_CAMPAIGN_ID: 1` ⚠️ | **10** ❌ | missing |

**`WORK_UNIT_FETCH_COUNT`** is now a *floor*, not a fixed size — the worker resizes each cycle from measured throughput — and it must stay small enough that a batch fits inside a stage. 250,000 is the exact value that pinned batches at ~1 s spanning several stages, so every one was abandoned partway. All four now use 2,000.

**`TOP_RESULTS_COUNT`** was 10 on three configs against 50 in the main compose and the QM. Workers trim the shared top-N set to their *own* value, so a mixed fleet would fight over its size.

**`HOIST_ENABLED`** was documented nowhere but the main compose. It defaults to true, so behaviour was right, but the way to fall back to the seeded kernel was invisible.

**Vast.ai** moves from the legacy campaign pin to `RAMSEY_FLEET: vast-ai`, since that fleet row already exists — repointing burst instances becomes a DB update rather than an image rebuild.

**Dell and AWS** still pin `RAMSEY_CAMPAIGN_ID=1`, and campaign 1 has had no active stage since **2026-04-19** — those boxes would find no work as configured. Switching them to `RAMSEY_FLEET` needs a fleet row per platform, which is a data change rather than a config one, so they carry a comment saying so rather than a silently-broken fleet name.

All five compose files validate with `docker compose config`; both shell-embedded variants pass `bash -n` and the edits land inside the correct heredoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7XjzEBwfnWeVv9KRSrWWr