### PR TITLE
Log REST timings only when slow; fail deploys that lack MYSQL_PASSWORD

### DIFF
--- a/docker/dell-worker/ramsey-compose.yml
+++ b/docker/dell-worker/ramsey-compose.yml
@@ -25,6 +25,9 @@ services:
       # identical values, so this only ever trades cost.
       HOIST_ENABLED: "true"
       WORKER_COUNT: 1
+      # Per-stage/per-batch tracing. Off by default — each worker narrating every stage transition
+      # is ~4 lines per stage, which buried the events worth reading once stages sped up.
+      RAMSEY_LOG_DEBUG: "false"
     logging:
       driver: loki
       options:

--- a/docker/m1-worker/ramsey-compose.yml
+++ b/docker/m1-worker/ramsey-compose.yml
@@ -21,6 +21,9 @@ services:
       # identical values, so this only ever trades cost.
       HOIST_ENABLED: "true"
       WORKER_COUNT: 1
+      # Per-stage/per-batch tracing. Off by default — each worker narrating every stage transition
+      # is ~4 lines per stage, which buried the events worth reading once stages sped up.
+      RAMSEY_LOG_DEBUG: "false"
     logging:
       driver: loki
       options:

--- a/docker/main/ramsey-compose.yml
+++ b/docker/main/ramsey-compose.yml
@@ -33,11 +33,17 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: dev
       DB_USER: ramsey-user-dev
-      DB_PASS: ${MYSQL_PASSWORD}
+      # Fail the deploy rather than start a middleware that cannot authenticate to MySQL. Unset,
+      # this silently resolved to "" and recreated the container into a crash loop — which stops
+      # the whole search, since workers get their stage from here.
+      DB_PASS: ${MYSQL_PASSWORD:?set MYSQL_PASSWORD before deploying (see database/README.md)}
       JDBC_BATCH_SIZE: 5000
       REDIS_HOST: redis
       REDIS_PORT: 6379
       LOGGING_LEVEL_ROOT: INFO
+      # Per-request timing logs at INFO only at/above this many ms (or on non-2xx). Workers poll
+      # the fleet active-stage endpoint every cycle; logging each one was ~73 lines/sec.
+      REQUEST_LOG_SLOW_MS: 250
     depends_on:
       - redis
     logging:
@@ -142,6 +148,10 @@ services:
       HOIST_ENABLED: "true"
       TOP_RESULTS_COUNT: 50
       WORKER_COUNT: 1
+      # Per-stage and per-batch tracing. Off by default: 14 workers each narrating every stage
+      # transition is ~56 lines per stage, which at the post-hoist stage rate buried the events
+      # worth reading. Set true on a single worker to get that detail back for debugging.
+      RAMSEY_LOG_DEBUG: "false"
     depends_on:
       ramsey-mw:
         condition: service_healthy

--- a/src/main/java/com/setminusx/ramsey/mw/config/RequestTimingConfig.java
+++ b/src/main/java/com/setminusx/ramsey/mw/config/RequestTimingConfig.java
@@ -4,18 +4,41 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * Times every request, but only reports the ones worth reading.
+ *
+ * <p>One INFO line per request was affordable when workers polled every few seconds. It stopped
+ * being affordable once the pair-move hoist raised the stage rate: every worker in the fleet polls
+ * {@code /fleets/{fleet}/active-stage} each cycle, which by itself accounted for ~73 lines/sec —
+ * about two thirds of everything this service logged, essentially all of it reporting that a 1 ms
+ * call took 1 ms.
+ *
+ * <p>What the timing log is genuinely good for is catching an endpoint that has become slow (it is
+ * how a 20–28 ms per-cycle fleet lookup was found). That is preserved: anything at or above
+ * {@code slowThresholdMs}, and anything that did not return 2xx, still logs at INFO. The rest drops
+ * to DEBUG, recoverable by raising the level rather than by a code change.
+ */
 @Slf4j
 @Component
 @Profile({ "local", "dev" })
 public class RequestTimingConfig implements WebMvcConfigurer {
 
     private static final String START_TIME_ATTRIBUTE = "startTime";
+
+    /**
+     * Requests at or above this many milliseconds log at INFO. Env: REQUEST_LOG_SLOW_MS.
+     * The default sits well above the healthy cost of the polling endpoints (~1 ms) and below the
+     * campaign progression fetch (~370 ms), so a regression in either is still visible.
+     */
+    @Value("${ramsey.request-log.slow-threshold-ms:250}")
+    private long slowThresholdMs;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -30,13 +53,21 @@ public class RequestTimingConfig implements WebMvcConfigurer {
             @Override
             public void afterCompletion(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response,
                     @NotNull Object handler, Exception ex) {
-                long startTime = (Long) request.getAttribute(START_TIME_ATTRIBUTE);
-                long duration = System.currentTimeMillis() - startTime;
-                log.info("REST Request {} {} completed in {}ms with status {}",
-                        request.getMethod(),
-                        request.getRequestURI(),
-                        duration,
-                        response.getStatus());
+                Object startTime = request.getAttribute(START_TIME_ATTRIBUTE);
+                if (startTime == null) {
+                    return;
+                }
+                long duration = System.currentTimeMillis() - (Long) startTime;
+                int status = response.getStatus();
+                boolean notable = duration >= slowThresholdMs || status < 200 || status >= 300;
+
+                if (notable) {
+                    log.info("REST Request {} {} completed in {}ms with status {}",
+                            request.getMethod(), request.getRequestURI(), duration, status);
+                } else if (log.isDebugEnabled()) {
+                    log.debug("REST Request {} {} completed in {}ms with status {}",
+                            request.getMethod(), request.getRequestURI(), duration, status);
+                }
             }
         });
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,11 @@ ramsey:
     page-size:
       default: 5
       max: 500
+  request-log:
+    # Per-request timing logs at INFO only when a request is at least this slow (or non-2xx).
+    # Every worker polls the fleet active-stage endpoint each cycle, so logging every request
+    # scaled with fleet speed rather than with anything worth reading.
+    slow-threshold-ms: ${REQUEST_LOG_SLOW_MS:250}
 
 spring:
   jpa:


### PR DESCRIPTION
## Problem 1 — per-request logging

`RequestTimingConfig` logged one INFO line per request. Every worker polls `/fleets/{fleet}/active-stage` each cycle, so that endpoint alone was **~73 lines/sec** — about two thirds of everything this service logged, essentially all of it reporting that a 1 ms call took 1 ms.

What the timing log is genuinely good for is catching an endpoint that has *become* slow — it is how a 20–28 ms per-cycle fleet lookup was found earlier. So that is preserved rather than deleted:

- INFO at or above `REQUEST_LOG_SLOW_MS` (default **250 ms**), or on any non-2xx status
- everything else drops to DEBUG, recoverable by raising the level rather than by a code change
- the start-time attribute is now guarded instead of unconditionally unboxed

The default sits well above the healthy cost of the polling endpoints (~1 ms) and below the campaign progression fetch (~370 ms), so a regression in either direction stays visible.

## Problem 2 — silent blank DB password

`DB_PASS: ${MYSQL_PASSWORD}` silently resolved to `""` when the variable was unset in the deploying shell. That recreated the middleware into a crash loop on Hibernate dialect detection — **which stops the entire search**, since workers get their stage from here. It caused a ~10 minute outage during this work.

Now `${MYSQL_PASSWORD:?...}`, so compose refuses to deploy rather than starting a middleware that cannot authenticate. Verified both directions:

```
without MYSQL_PASSWORD → exit 1, "required variable MYSQL_PASSWORD is missing a value"
with    MYSQL_PASSWORD → exit 0
```

## Also

Documents `RAMSEY_LOG_DEBUG` on the main/m1/dell worker compose files so the worker-side tracing toggle is discoverable from where it is configured.

## Measured

| | before | after |
|---|---|---|
| mw log rate | 74–108/s | **3/s** |
| fleet-wide | 135/s (13M lines/day) | **13/s (1.1M/day)** |

18 tests green; mw healthy, 0 errors, campaign min 25,758 intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7XjzEBwfnWeVv9KRSrWWr