### PR TITLE
Size the active-stage cache against the stage rate, not the DB

### DIFF
--- a/src/main/java/com/setminusx/ramsey/mw/service/FleetService.java
+++ b/src/main/java/com/setminusx/ramsey/mw/service/FleetService.java
@@ -25,6 +25,15 @@ public class FleetService {
      * almost all of that load while bounding how long a worker can be handed a stage that has just
      * been superseded.
      *
+     * Sized against the stage cadence, not against database cost. At 250ms this TTL was ~98% of a
+     * stage's lifetime during a post-kick descent (stages advance ~3.9/sec, so a stage lives
+     * ~256ms), which meant a worker could be handed a pointer to an already-dead stage for
+     * essentially the whole of the next one, then pay a wasted cycle and a retry sleep when the
+     * config it asked Redis for had already been deleted. The original 250ms was chosen when this
+     * lookup was an 11.8ms full table scan; the index made that 0.135ms and removed the reason for
+     * a long TTL, but it was never retuned as the stage rate climbed. Keep this well under the
+     * shortest stage we expect to see.
+     *
      * Only a RESOLVED stage is cached. An empty answer is deliberately never cached: a stage
      * advance briefly leaves a campaign with no ACTIVE stage, and a worker that sees that gap
      * treats the fleet as paused and drops its cached graph and hoist tables — which costs a full
@@ -32,7 +41,7 @@ public class FleetService {
      * gap would stretch a millisecond-wide race into a quarter-second outage. Re-reading is cheap
      * now that the stage table is indexed (0.135ms).
      */
-    private static final long ACTIVE_STAGE_CACHE_MILLIS = 250;
+    private static final long ACTIVE_STAGE_CACHE_MILLIS = 25;
 
     private final FleetRepo fleetRepo;
     private final StageRepo stageRepo;


### PR DESCRIPTION
## Problem

`ACTIVE_STAGE_CACHE_MILLIS` was **250ms**. During a post-kick descent stages advance ~3.9/sec, so a stage lives **~256ms** — the TTL was ~98% of it. A worker asking "what should I work on?" could be handed a pointer to an already-retired stage for essentially the whole of the next one. Asking Redis for that stage's config then missed, because the queue manager deletes it as soon as the successor is live, costing a wasted cycle and a retry sleep.

Of the config-missing races observed on a worker, **83 of 85 were on stages more than two behind current** — this staleness, not a stage that wasn't ready yet.

## Why it was 250ms

That value was chosen when this lookup was an **11.8ms full table scan**. The `idx_stage_campaign_status` index made it **0.135ms** and removed the reason for a long TTL, but it was never retuned as the stage rate climbed. This is a case of a cache outliving its justification.

## Change

250ms → **25ms**, sized against the stage cadence rather than database cost. The javadoc now says to keep it well under the shortest stage we expect, so the next person retunes it deliberately.

## Measured cost on the live fleet

| | before | after |
|---|---|---|
| middleware CPU | 3.58% | 4.68% |
| MySQL CPU | 5.04% | 6.09% |
| sweep throughput | ~31M u/s | 31.2M / 30.0M u/s |

About a percentage point each for 10× the lookups, and throughput unchanged within its normal band.

## Caveat

The fleet returned to the near-floor wall regime (stages ~6.7s) before the benefit could be observed live — at that cadence a 25ms cache cannot go stale, so the 0 races currently seen is the *expected* reading, not a demonstration. The win applies to the fast-descent regime and will show at the next perturbation kick.

18 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7XjzEBwfnWeVv9KRSrWWr