### PR TITLE
Correct the all-time best across the investigation docs: 25,604

### DIFF
--- a/docs/investigations/README.md
+++ b/docs/investigations/README.md
@@ -1,6 +1,6 @@
 # Investigations — index
 
-Goal throughout: a 282-vertex 2-coloring with zero monochromatic K₈ ⇒ **R(8,8) ≥ 283**. Best-known 282-graph: **25,758** mono-8 (graph 26994, set by a perturbation kick on campaign 10). The older 25,840 (graph 8644) is still referenced by pre-July docs.
+Goal throughout: a 282-vertex 2-coloring with zero monochromatic K₈ ⇒ **R(8,8) ≥ 283**. Best-known 282-graph: **25,604** mono-8 (graph 276750, campaign 10, 2026-07-28). Superseded values still referenced by older docs, newest first: 25,618 (graph 222120, 2026-07-27), 25,758 (graph 26994), 25,840 (graph 8644). **Anything reading "nothing has ever gone below 25,840" predates 2026-07-27 and is no longer true.**
 
 **Start here:** `july-2026-next-steps.md` (live roadmap) → `search-status-2026-06-14.md` (consolidated findings + do-not-retry list).
 

--- a/docs/investigations/july-2026-next-steps.md
+++ b/docs/investigations/july-2026-next-steps.md
@@ -4,14 +4,16 @@
 **Author:** Ben Ferenchak + Claude
 **Supersedes:** `archive/may-2026-next-steps.md` as the live roadmap. Strategic background: `search-status-2026-06-14.md` (read first), `structurally-new-base-investigation.md` (all construction long shots closed through order 461 + all four order-282 Cayley groups), `windowed-maxsat-investigation.md` (~1.1M exact windows, zero escapes).
 
-**Goal unchanged:** a 282-vertex 2-coloring with zero monochromatic K₈ → **R(8,8) ≥ 283**. Best-known 282-graph: **25,840 mono-8 (graph 8644, 2026-06-16)** — still the all-time best; unbeaten by any of the six basins or two deep-wall re-runs since.
+**Goal unchanged:** a 282-vertex 2-coloring with zero monochromatic K₈ → **R(8,8) ≥ 283**. Best-known 282-graph: **25,604 mono-8 (graph 276750, campaign 10, 2026-07-28)**. The 25,840 figure below is the state as of 2026-07-02 and has since been beaten three times (25,758 → 25,618 → 25,604), all by ILS perturbation kicks on campaign 10.
 
 ---
 
 ## CURRENT STATE (2026-07-26) — read this first; everything below is an older snapshot
 
-- **All-time best is now 25,758** (graph 26994), set by a perturbation kick on campaign 10 —
-  the first time anything has beaten the long-standing 25,840. Still not a witness (≠ 0).
+- **All-time best is now 25,604** (graph 276750, 2026-07-28 11:01), set by a perturbation kick on
+  campaign 10. Still not a witness (≠ 0). Progression of record-holders: 25,840 (graph 8644,
+  06-16) → 25,758 (graph 26994) → 25,618 (graph 222120, 07-27) → **25,604** (graph 276750, 07-28).
+  The last two arrived within a day of each other, both from x32 kicks off the then-incumbent.
 - **Perturbation kicks now fire on BASIN STALENESS, not a fixed wall.** The clock runs from the
   basin's own floor, so a descent still finding new minima is never cut off. The old fixed
   `PERTURBATION_WALL_STAGES` truncated seven campaign-10 descents mid-free-fall.

--- a/docs/investigations/multiseed-basin-program-results.md
+++ b/docs/investigations/multiseed-basin-program-results.md
@@ -1,5 +1,13 @@
 # Multi-seed basin program — results
 
+> **SUPERSEDED IN PART (2026-07-28).** The basin-floor table below is unchanged and still correct:
+> those six seeds, under single/dual edge flips, did floor at 25,840–26,677. But its framing —
+> "25,840 is a genuine deep floor for this move class" — has since been beaten **three times** by
+> ILS perturbation kicks on campaign 10: 25,758 (graph 26994) → 25,618 (graph 222120, 07-27) →
+> **25,604** (graph 276750, 07-28). What the program actually established is that *plain descent
+> from a fresh Paley+row-opt seed* floors at ~25.8–26.7K; adding escalating kicks to an incumbent
+> goes lower. Read the conclusions below as scoped to the no-kick regime they were measured in.
+
 **Ran:** 2026-07-02 → 2026-07-13 (campaigns 11–15 serial on the local 14-worker fleet;
 campaign 10 concurrent on the second machine). **All effort figures are stage counts**
 (1 stage = one full ~392M-unit sweep of a base graph); wall-clock is not comparable


### PR DESCRIPTION
Docs-only.

Three docs carried three different, all stale, values for the best known 282-graph. The actual best is **25,604** (graph 276750, campaign 10, 2026-07-28 11:01), verified against the DB.

| doc | said | actual |
|---|---|---|
| `README.md` | 25,758 | **25,604** |
| `july-2026-next-steps.md` header | 25,840 | **25,604** |
| `july-2026-next-steps.md` current-state | 25,758 | **25,604** |

Progression of record-holders:

```
25,840  graph 8644    2026-06-16
25,758  graph 26994
25,618  graph 222120  2026-07-27 16:22
25,604  graph 276750  2026-07-28 11:01
```

The last two landed within a day of each other, both from x32 perturbation kicks off the then-incumbent.

## Why this is more than housekeeping

These headers are what future decisions get calibrated against — whether a basin floor is good, whether a deep-wall re-run cashed in, whether a kick earned its compute. Several conclusions are phrased as *"nothing has ever gone below 25,840"*, which stopped being true on 07-27. The README now says that explicitly rather than leaving the reader to notice.

## Scoping banner on the multi-seed results

Its floor table is unchanged and still correct — those six seeds did floor at 25,840–26,677 under single/dual edge flips. But its framing (*"25,840 is a genuine deep floor for this move class"*) has been beaten three times since.

What the program actually established is that **plain descent from a fresh Paley+row-opt seed** floors at ~25.8–26.7K; **escalating kicks against an incumbent** go lower. The conclusions are now marked as scoped to the no-kick regime they were measured in, rather than silently reading as still-current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7XjzEBwfnWeVv9KRSrWWr